### PR TITLE
fix: remove custom hover override from mobile chat button

### DIFF
--- a/src/components/CustomChatUI.vue
+++ b/src/components/CustomChatUI.vue
@@ -945,13 +945,6 @@ export default {
     transform: translateY(calc(100% + var(--spacing-md)));
     pointer-events: none;
   }
-
-  .chat-button--mobile .custom-btn:hover:not(:disabled) {
-    color: var(--foreground) !important;
-    background: var(--background) !important;
-    border-color: var(--foreground) !important;
-    opacity: 1;
-  }
 }
 
 .chat-button-desktop-wrapper {


### PR DESCRIPTION
Removes the custom hover block for `.chat-button--mobile .custom-btn:hover` that was overriding MyButton's built-in solid hover with explicit color/background values, causing text to be invisible on hover.