### PR TITLE
fix: filter out unpublished entries from CardRow2

### DIFF
--- a/src/components/CardRow2.vue
+++ b/src/components/CardRow2.vue
@@ -209,6 +209,9 @@ export default {
       const currentRoute = this.$route;
       let items = this.resolvedItems;
 
+      // Exclude unpublished items
+      items = items.filter((item) => item.published !== false);
+
       // Filter by type if filterByType prop is provided
       if (this.filterByType) {
         items = items.filter((item) => item.type === this.filterByType);

--- a/src/components/CustomChatUI.vue
+++ b/src/components/CustomChatUI.vue
@@ -945,13 +945,6 @@ export default {
     transform: translateY(calc(100% + var(--spacing-md)));
     pointer-events: none;
   }
-
-  .chat-button--mobile .custom-btn:hover:not(:disabled) {
-    color: var(--foreground) !important;
-    background: var(--background) !important;
-    border-color: var(--foreground) !important;
-    opacity: 1;
-  }
 }
 
 .chat-button-desktop-wrapper {


### PR DESCRIPTION
Excludes items with `published: false` from all CardRow2 renders, preventing the Case Study Template from appearing in Select Work.