### PR TITLE
content: update homepage about section to match /info tone

### DIFF
--- a/src/components/CardRow2.vue
+++ b/src/components/CardRow2.vue
@@ -209,6 +209,9 @@ export default {
       const currentRoute = this.$route;
       let items = this.resolvedItems;
 
+      // Exclude unpublished items
+      items = items.filter((item) => item.published !== false);
+
       // Filter by type if filterByType prop is provided
       if (this.filterByType) {
         items = items.filter((item) => item.type === this.filterByType);

--- a/src/components/CustomChatUI.vue
+++ b/src/components/CustomChatUI.vue
@@ -945,13 +945,6 @@ export default {
     transform: translateY(calc(100% + var(--spacing-md)));
     pointer-events: none;
   }
-
-  .chat-button--mobile .custom-btn:hover:not(:disabled) {
-    color: var(--foreground) !important;
-    background: var(--background) !important;
-    border-color: var(--foreground) !important;
-    opacity: 1;
-  }
 }
 
 .chat-button-desktop-wrapper {

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -24,7 +24,7 @@
         as="h2"
         description=""
         eyebrow1=""
-        :detail1="`Head of Design at Orium, Toronto. For ${careerYears} years I’ve been closing the gap between design and engineering—building token-based design systems, shipping production code, and designing AI-native products from scratch.<br/><br/>I build AI agents and partner with clients to explore and realize agentic experience (AX) possibilities—helping teams move past AI hype into real, user-centred AI products. I coach designers into unicorns—people who think in systems, write production code, and own the full delivery stack.`"
+        :detail1="`Head of Design at Orium, Toronto. ${careerYears} years at the seam between design and engineering, designing systems, writing production code, and lately building with AI.<br/><br/>I care most about the gap between design intent and what actually ships: how decisions survive handoff, how systems scale, and how people stay in control when the tools get smarter. I also coach designers moving closer to systems and code, not because everyone needs to write code, but because fluency changes the kinds of conversations you can have.`"
       />
     </AnimatedComponent>
 


### PR DESCRIPTION
Replace marketing copy with the more direct voice from /info: gap between design intent and what ships, fluency framing for coaching, same approximate length.