### PR TITLE
Rename Sketchbook section to Explorations

### DIFF
--- a/src/assets/content/doc_63.md
+++ b/src/assets/content/doc_63.md
@@ -1,6 +1,6 @@
-# Sketchbook
+# Explorations
 
-Visual explorations, UI experiments, and work-in-progress from across projects.
+UI experiments, design process, and work-in-progress from across projects.
 
 <!-- full-width -->
 

--- a/src/assets/data/library.json
+++ b/src/assets/data/library.json
@@ -432,14 +432,14 @@
     {
       "id": 70,
       "type": "design-project",
-      "title": "Visual Sketchbook",
+      "title": "Explorations",
       "eyebrow": "Visual Design",
-      "description": "A running collection of visual design explorations, UI experiments, and work-in-progress screenshots from across projects.",
-      "route": "/Sketchbook",
+      "description": "UI experiments, design process, and work-in-progress from across projects.",
+      "route": "/explorations",
       "thumbnail": "avatar/avatar.svg",
       "filename1": "avatar/avatar.svg",
-      "alt": "Visual Sketchbook — Design explorations and experiments",
-      "tags": ["visual-design", "sketchbook"]
+      "alt": "Explorations: design work and process",
+      "tags": ["visual-design", "explorations"]
     },
 
     {
@@ -460,7 +460,7 @@
     },
     {
       "docId": 63,
-      "slug": "sketchbook",
+      "slug": "explorations",
       "contentFile": "doc_63.md"
     },
     {

--- a/src/pages/Explorations.vue
+++ b/src/pages/Explorations.vue
@@ -113,7 +113,7 @@ function buildProjects() {
 }
 
 export default {
-  name: 'MySketchbook',
+  name: 'Explorations',
   components: { FullscreenImage, ImageCard },
   data() {
     return {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import TheLogin from '@/components/TheLogin.vue';
 
 import { createRouter, createWebHistory } from 'vue-router';
-import MySketchbook from '@/pages/MySketchbook.vue';
+import Explorations from '@/pages/Explorations.vue';
 import DesignSystem from '@/pages/DesignSystem.vue';
 import MaintenancePage from '@/pages/misc/MaintenancePage.vue';
 import MyResume from '@/pages/MyResume.vue';
@@ -110,11 +110,11 @@ const routes = [
     component: PlayIndex,
   },
   {
-    name: 'MySketchbook',
-    path: '/sketchbook',
-    component: MySketchbook,
+    name: 'Explorations',
+    path: '/explorations',
+    component: Explorations,
     meta: {
-      title: 'Sketchbook',
+      title: 'Explorations',
     },
   },
   {


### PR DESCRIPTION
Renames "Visual Sketchbook" to "Explorations" across route, page component, library card, doc title, and description. Updates route from /sketchbook to /explorations.

https://claude.ai/code/session_01HgSbJchaQME6YXxCKEmGEB