### PR TITLE
Rename Sketchbook section to Explorations

### DIFF
--- a/src/pages/Explorations.vue
+++ b/src/pages/Explorations.vue
@@ -113,7 +113,7 @@ function buildProjects() {
 }
 
 export default {
-  name: 'Explorations',
+  name: 'MyExplorations',
   components: { FullscreenImage, ImageCard },
   data() {
     return {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Renames "Visual Sketchbook" to "Explorations" across route, page component, library card, doc title, and description
- Updates route from `/sketchbook` to `/explorations`
- Fixes alt text to use colon instead of em dash (per writing rules)
- Fixes Vue lint error: component name updated to `MyExplorations`

## Test plan
- [ ] Visit `/explorations` — page loads correctly
- [ ] Nav/card links to the section resolve
- [ ] Old `/sketchbook` route no longer needed (no redirects required unless SEO matters)

https://claude.ai/code/session_01HgSbJchaQME6YXxCKEmGEB
EOF
)