### PR TITLE
Fix word counter CI and disable hero banner effect

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         run: pnpm build:word-counter
 
       - name: Copy Word Counter to dist
-        run: cp -r apps/unique-word-counter/build dist/play/word-counter
+        run: mkdir -p dist/play && cp -r apps/unique-word-counter/build dist/play/word-counter
 
       - name: Build Storybook
         run: pnpm build-storybook

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -211,9 +211,9 @@ export default {
         h1.id = 'hero-title';
         h1.classList.add('wrap-multi');
         document.fonts.ready.then(() => {
-          CounterFill.init({
-            'hero-title': { stops: ['var(--color-pink)', 'var(--color-lightyellow)'] },
-          });
+          // CounterFill.init({
+          //   'hero-title': { stops: ['var(--color-pink)', 'var(--color-lightyellow)'] },
+          // });
         });
       }
     });


### PR DESCRIPTION
## Summary

- CI was failing with `cp: cannot create directory 'dist/play/word-counter': No such file or directory` — added `mkdir -p dist/play` before the `cp` step in the deploy workflow
- Commented out `CounterFill.init` in `HomePage.vue` that was applying the word counter fill effect to the hero banner h1

## Test plan

- [ ] Confirm the "Copy Word Counter to dist" step passes in CI
- [ ] Verify the word counter app is accessible at `/play/word-counter/` after deploy
- [ ] Confirm home page hero title no longer shows the counter fill gradient effect

https://claude.ai/code/session_01Pzy5ajNaUkGkg4iFKJtrQg