### PR TITLE
Disable CounterFill effect on hero banner

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -211,9 +211,9 @@ export default {
         //        h1.id = 'hero-title';
         h1.classList.add('wrap-multi');
         document.fonts.ready.then(() => {
-          CounterFill.init({
-            'hero-title': { stops: ['var(--color-pink)', 'var(--color-lightyellow)'] },
-          });
+          // CounterFill.init({
+          //   'hero-title': { stops: ['var(--color-pink)', 'var(--color-lightyellow)'] },
+          // });
         });
       }
     });


### PR DESCRIPTION
## Summary

- Comments out `CounterFill.init` in `HomePage.vue` to disable the gradient fill effect on the hero banner h1

## Test plan

- [ ] Confirm home page hero title no longer shows the counter fill gradient effect

https://claude.ai/code/session_01Pzy5ajNaUkGkg4iFKJtrQg