### PR TITLE
Fix prerender baking dev-server origin into content image URLs

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -116,6 +116,7 @@ function startServer() {
 //      derived from the rendered content (the app leaves these generic for
 //      docs that carry their heading in the markdown body rather than a
 //      <header> block)
+//    - rewrite any baked-in prerender-server origin to root-relative paths
 //    - drop the now-inaccurate "requires JavaScript" <noscript> notice
 // ---------------------------------------------------------------------------
 function absoluteUrl(route) {
@@ -172,6 +173,13 @@ function finalizeHtml(html, route, pageMeta) {
       out = setMetaContent(out, 'property=["\']twitter:description["\']', desc);
     }
   }
+
+  // Strip the prerender server's origin. Some in-content images (e.g. article
+  // hero/body images) resolve to absolute URLs against the page origin at
+  // render time, which bakes http://localhost:<PORT> into the snapshot —
+  // broken and mixed-content-blocked on the live HTTPS domain. Rewriting to
+  // root-relative (/img/...) resolves correctly on any host.
+  out = out.replace(new RegExp(`https?://localhost:${PORT}`, 'g'), '');
 
   // Remove the JavaScript-required notice: the content is now in the HTML.
   out = out.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');


### PR DESCRIPTION
## Problem

Follow-up to #210. The prerender step captured `http://localhost:8177/img/...` into article hero and body image `src` attributes — those images resolve to absolute URLs against the page origin at render time, so the running prerender server's origin got baked into the snapshot.

On the live HTTPS site that URL is dead: the image 404s and is mixed-content-blocked. The Genie article (`/doc/building-genie-changed-me`) had a broken hero plus two broken inline images; any doc whose markdown body renders images was affected the same way.

## Fix

One targeted change in `scripts/prerender.mjs`: after snapshotting each page, strip the prerender server's origin so those paths become root-relative (`/img/...`), which resolves correctly on any host. Page chrome (nav, footer, cards) was already root-relative and unaffected.

## Verification

Rebuilt and checked the output:
- **0** `localhost` URLs across all 53 prerendered pages (was 3 in the Genie article).
- Genie images now `/img/genie.d0c5b0c0.png`, `/img/gennifer.4cad66f6.png`, `/img/genie.5664dcda.png` — all three files exist in `dist/img/`.
- Spot-checked other image-heavy docs (`counter-fill`): no `localhost` srcs.

No visual, content, or copy changes. Prerendered output (`dist/`) is gitignored and regenerated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6DwEayrZYHjkEAxrCB1Mt)_