### PR TITLE
CI: run Pages deploy on Node 20 (fix Playwright install failure)

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Setup Pages


### PR DESCRIPTION
## Problem

The Pages deploy (added in #210, extended in #212) fails at the **Install Playwright Chromium** step:

```
You are running Node.js 18.20.8.
Playwright requires Node.js 20 or higher.
Error: Process completed with exit code 1
```

The workflow pinned the runner to Node 18, which the current Playwright no longer supports. As a result #212's content (RSS, llms.txt, structured data) never published — the live site is still serving the #211 build. Node 18 is also EOL (the runs were already emitting deprecation warnings).

## Fix

Bump `actions/setup-node` to **Node 20** in `gh-pages-deploy.yml`. The Vue CLI 5 build and the prerender step are unaffected (verified locally on Node 20/22 throughout this work).

## Note (not changed here)

`.nvmrc` still pins `18.3.0` for local dev; the workflow sets its Node version explicitly so this doesn't affect CI, but you may want to bump `.nvmrc` too so a local `pnpm build` (which runs the Playwright prerender) doesn't hit the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6DwEayrZYHjkEAxrCB1Mt)_