### PR TITLE
Make the template course live but unlisted (drop the access gate)

### DIFF
--- a/src/assets/data/course-template.json
+++ b/src/assets/data/course-template.json
@@ -2,7 +2,7 @@
   "slug": "course-template",
   "title": "Course Template",
   "subtitle": "A reusable scaffold for a multipage course: a hub, ordered chapters, progress tracking, and cross-page navigation. Duplicate this manifest, point it at your own chapter docs, and you have a new course.",
-  "locked": true,
+  "locked": false,
   "entries": [
     {
       "id": 1,


### PR DESCRIPTION
## What this does

Sets `"locked": false` on `course-template.json` so the course hub loads at its URL with **no secret required**. It stays **unlisted** — nothing links to `/course/course-template` from any nav, so it's reachable only by knowing the URL (the same model as the site's other unlisted content).

## Why

The gated version required a `?unlock=preview` on the first visit, and deep-linking to a guarded route on a static host returns a real 404 from GitHub Pages before the SPA can recover — fragile and confusing. Unlisted-but-live avoids that entirely.

## Change

- `course-template.json`: `"locked": true` → `"locked": false` (one line).

The soft-gate infrastructure (`courseAccess` + the router guard) stays in place for any future course that sets `"locked": true`; it's simply inert for this one now.

## After merge

Live at `https://ramphal.design/course/course-template` (no secret, not linked anywhere). Chapters at `https://ramphal.design/secured/doc/course-template-overview` and the two that follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn)_