### PR TITLE
Course hub cards: single-source list styling with conditional check

### DIFF
--- a/src/components/card/ArticleCard/ArticleCard.vue
+++ b/src/components/card/ArticleCard/ArticleCard.vue
@@ -486,6 +486,21 @@ export default {
   transform: translateY(-50%);
 }
 
+// In a list row the badge sits centred at the right edge. On desktop the empty
+// third column holds it (no reflow); on mobile the row spans full width, so
+// reserve a gutter — but only when actually read, so non-course cards that use
+// the same list/mobile-list variants are never affected.
+.defaultcard--list .read-badge,
+.defaultcard--mobile-list .read-badge {
+  inset-block-start: 50%;
+  inset-inline-end: 0;
+  transform: translateY(-50%);
+}
+
+.defaultcard--read.defaultcard--mobile-list {
+  padding-inline-end: var(--spacing-lg);
+}
+
 /* Locked card state */
 .defaultcard--locked {
   cursor: help;
@@ -647,13 +662,21 @@ img {
   transition: height 0.25s ease-in-out;
 }
 
+// Canonical list-row style (single source of truth). Used by the Library list
+// view and the course hub. Reproduces the Library list card exactly: a
+// top-bordered row, no image, full-size title + description.
 .defaultcard--list {
   @media only screen and (min-width: 768px) {
     @include list-row-base;
+    height: auto !important;
     padding-block-start: var(--spacing-sm);
     display: grid !important;
     grid-template-columns: repeat(3, 1fr);
     grid-gap: var(--spacing-xs);
+
+    &:first-child {
+      border-block-start: none !important;
+    }
 
     .image {
       grid-column: 3 / 4;
@@ -678,11 +701,25 @@ img {
     }
 
     .info {
-      grid-column: 1 / 4;
+      // Spans two of three columns, leaving the third empty — this is where a
+      // conditional field (e.g. the completion check) sits without reflowing.
+      grid-column: 1 / 3;
       grid-row: 1;
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
+
+      &:not(:has(.color-bar)) {
+        padding-block-start: 0 !important;
+      }
+    }
+
+    // A list row is often also `borderless`. The borderless variant adds its
+    // own info padding; the list layout must win so rows stay flush. The
+    // compound selector outranks `.defaultcard--borderless .info` regardless of
+    // source order.
+    &.defaultcard--borderless .info {
+      padding: 0 !important;
 
       &:not(:has(.color-bar)) {
         padding-block-start: 0 !important;

--- a/src/components/card/ArticleCard/ArticleCard.vue
+++ b/src/components/card/ArticleCard/ArticleCard.vue
@@ -678,6 +678,17 @@ img {
       border-block-start: none !important;
     }
 
+    // A list row is often also `borderless`, whose `border: none` would drop
+    // the divider. The compound selector outranks it so the top-border divider
+    // survives.
+    &.defaultcard--borderless {
+      border-block-start: var(--border) !important;
+
+      &:first-child {
+        border-block-start: none !important;
+      }
+    }
+
     .image {
       grid-column: 3 / 4;
       grid-row: 1;

--- a/src/pages/CoursePage.vue
+++ b/src/pages/CoursePage.vue
@@ -10,13 +10,14 @@
         <p class="subtle course-progress__label">{{ readCount }} of {{ totalCount }} complete</p>
       </div>
 
-      <GridParent tight rows class="posts posts--list chapters">
+      <GridParent tight rows class="chapters">
         <template v-for="chapter in course.entries">
           <ArticleCard
             v-if="chapter.published"
             :key="`chapter-${chapter.id}`"
-            borderless
+            list
             mobileList
+            borderless
             type="chapter"
             :eyebrow="chapter.tag"
             :title="chapter.title"
@@ -130,69 +131,10 @@ export default {
   flex-shrink: 0;
 }
 
-// Match the Library list-view card exactly (see MyLibrary.vue). The desktop
-// list look — top-bordered rows, no image, full-size title — is applied to the
-// same `.posts--list` container the Library uses; mobile is handled by the
-// card's own `mobileList` styles. This is intentionally the same rule set so
-// course rows and Library rows stay visually identical.
-@media only screen and (min-width: 768px) {
-  .posts--list :deep(.default-card:not(.defaultcard--featured)) {
-    border-radius: 0 !important;
-    box-shadow: none !important;
-    border: none !important;
-    border-block-start: var(--border) !important;
-    min-height: 0 !important;
-    height: auto !important;
-    padding-block: var(--spacing-xs);
-    padding-block-start: var(--spacing-sm);
-    display: grid !important;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--spacing-xs);
-
-    &:first-child {
-      border-block-start: none !important;
-    }
-    &:hover {
-      background: transparent;
-      box-shadow: none !important;
-    }
-  }
-
-  .posts--list :deep(.default-card:not(.defaultcard--featured) .image) {
-    display: none !important;
-  }
-
-  .posts--list :deep(.default-card:not(.defaultcard--featured) .info) {
-    grid-column: 1 / 3;
-    grid-row: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    padding: 0 !important;
-  }
-
-  .posts--list :deep(.default-card:not(.defaultcard--featured) .card-footer) {
-    padding-block-start: var(--spacing-xxs);
-    margin-block-start: auto;
-  }
-}
-
-// Completion check, centred against the row. On desktop the Library layout
-// leaves the third column empty (info spans 1 / 3), so the check sits there
-// with no change to the row — an exact match to the Library card. Only mobile,
-// where the info spans full width, needs a reserved gutter so the check never
-// overlaps the title.
-.chapters :deep(.default-card .read-badge) {
-  inset-block-start: 50%;
-  inset-inline-end: 0;
-  transform: translateY(-50%);
-}
-
-@media only screen and (max-width: 767px) {
-  .chapters :deep(.default-card) {
-    padding-inline-end: var(--spacing-lg);
-  }
-}
+// The list-row styling and the completion check live in ArticleCard (the
+// single source — `list` + `mobileList` + the conditional `read` field), so
+// the hub needs no card CSS of its own. It renders identically to the Library
+// list cards.
 
 .chapter-row--soon {
   display: flex;

--- a/src/pages/CoursePage.vue
+++ b/src/pages/CoursePage.vue
@@ -177,16 +177,21 @@ export default {
   }
 }
 
-// Completion check: keep clear of the title by reserving a right gutter, and
-// centre it against the row.
-.chapters :deep(.default-card) {
-  padding-inline-end: var(--spacing-lg);
-}
-
+// Completion check, centred against the row. On desktop the Library layout
+// leaves the third column empty (info spans 1 / 3), so the check sits there
+// with no change to the row — an exact match to the Library card. Only mobile,
+// where the info spans full width, needs a reserved gutter so the check never
+// overlaps the title.
 .chapters :deep(.default-card .read-badge) {
   inset-block-start: 50%;
   inset-inline-end: 0;
   transform: translateY(-50%);
+}
+
+@media only screen and (max-width: 767px) {
+  .chapters :deep(.default-card) {
+    padding-inline-end: var(--spacing-lg);
+  }
 }
 
 .chapter-row--soon {

--- a/src/pages/CoursePage.vue
+++ b/src/pages/CoursePage.vue
@@ -10,13 +10,13 @@
         <p class="subtle course-progress__label">{{ readCount }} of {{ totalCount }} complete</p>
       </div>
 
-      <GridParent tight rows class="chapters">
+      <GridParent tight rows class="posts posts--list chapters">
         <template v-for="chapter in course.entries">
           <ArticleCard
             v-if="chapter.published"
             :key="`chapter-${chapter.id}`"
-            indexRow
             borderless
+            mobileList
             type="chapter"
             :eyebrow="chapter.tag"
             :title="chapter.title"
@@ -128,6 +128,65 @@ export default {
   margin: 0;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+// Match the Library list-view card exactly (see MyLibrary.vue). The desktop
+// list look — top-bordered rows, no image, full-size title — is applied to the
+// same `.posts--list` container the Library uses; mobile is handled by the
+// card's own `mobileList` styles. This is intentionally the same rule set so
+// course rows and Library rows stay visually identical.
+@media only screen and (min-width: 768px) {
+  .posts--list :deep(.default-card:not(.defaultcard--featured)) {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    border: none !important;
+    border-block-start: var(--border) !important;
+    min-height: 0 !important;
+    height: auto !important;
+    padding-block: var(--spacing-xs);
+    padding-block-start: var(--spacing-sm);
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-xs);
+
+    &:first-child {
+      border-block-start: none !important;
+    }
+    &:hover {
+      background: transparent;
+      box-shadow: none !important;
+    }
+  }
+
+  .posts--list :deep(.default-card:not(.defaultcard--featured) .image) {
+    display: none !important;
+  }
+
+  .posts--list :deep(.default-card:not(.defaultcard--featured) .info) {
+    grid-column: 1 / 3;
+    grid-row: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    padding: 0 !important;
+  }
+
+  .posts--list :deep(.default-card:not(.defaultcard--featured) .card-footer) {
+    padding-block-start: var(--spacing-xxs);
+    margin-block-start: auto;
+  }
+}
+
+// Completion check: keep clear of the title by reserving a right gutter, and
+// centre it against the row.
+.chapters :deep(.default-card) {
+  padding-inline-end: var(--spacing-lg);
+}
+
+.chapters :deep(.default-card .read-badge) {
+  inset-block-start: 50%;
+  inset-inline-end: 0;
+  transform: translateY(-50%);
 }
 
 .chapter-row--soon {

--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -109,6 +109,7 @@
           >
             <ArticleCard
               borderless
+              :list="viewMode === 'list'"
               v-for="(entry, index) in filteredArticlesAndTools"
               :key="entry.id"
               :mobileList="index !== 0"
@@ -146,6 +147,7 @@
           >
             <ArticleCard
               borderless
+              :list="viewMode === 'list'"
               v-for="(entry, index) in filteredCaseStudiesAndProjects"
               :key="entry.id"
               :featured="viewMode !== 'list' && index === 0"
@@ -187,6 +189,7 @@
           >
             <ArticleCard
               borderless
+              :list="viewMode === 'list'"
               v-for="(entry, index) in filteredTools"
               :key="entry.id"
               :mobileList="index !== 0"
@@ -223,6 +226,7 @@
           >
             <ArticleCard
               borderless
+              :list="viewMode === 'list'"
               v-for="(entry, index) in filteredLabs"
               :key="entry.id"
               :mobileList="index !== 0"
@@ -280,6 +284,7 @@
         >
           <ArticleCard
             borderless
+            :list="viewMode === 'list'"
             mobileList
             v-for="(entry, index) in filteredEntries"
             :key="entry.id"
@@ -573,52 +578,9 @@ export default {
   grid-column: unset;
 }
 
-@media only screen and (min-width: 768px) {
-  .posts--list :deep(.default-card:not(.defaultcard--featured)) {
-    border-radius: 0 !important;
-    box-shadow: none !important;
-    border: none !important;
-    border-block-start: var(--border) !important;
-    min-height: 0 !important;
-    height: auto !important;
-    padding-block: var(--spacing-xs);
-    padding-block-start: var(--spacing-sm);
-    display: grid !important;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--spacing-xs);
-
-    &:first-child {
-      border-block-start: none !important;
-    }
-    &:hover {
-      background: transparent;
-      box-shadow: none !important;
-    }
-  }
-
-  .posts--list :deep(.default-card:not(.defaultcard--featured) .image) {
-    display: none !important;
-  }
-
-  .posts--list :deep(.default-card:not(.defaultcard--featured) .info) {
-    grid-column: 1 / 3;
-    grid-row: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    padding: 0 !important;
-  }
-
-  .posts--list :deep(.default-card:not(.defaultcard--featured) .card-footer) {
-    padding-block-start: var(--spacing-xxs);
-    margin-block-start: auto;
-    //   border-block-end: var(--border) !important;
-  }
-
-  // .posts--list :deep(.default-card:last-child) {
-  //   border-block-end: var(--border) !important;
-  // }
-}
+// The desktop list-row styling now lives in ArticleCard's `list` variant
+// (the single source), applied here via :list="viewMode === 'list'". Mobile is
+// handled by the card's `mobileList` variant as before.
 
 .view-toggle {
   display: none;


### PR DESCRIPTION
Follow-up to #218. Makes the course hub cards match the Library list cards by consolidating the list-row styling into one source, and keeps the completion check as a conditional field.

## Changes

- **Single source of truth.** The list-row style now lives only in `ArticleCard`'s `list` variant. Both the Library list view (`:list="viewMode === 'list'"`) and the course hub (`list mobileList`) draw from it; the duplicated CSS blocks in `MyLibrary.vue` and `CoursePage.vue` are removed.
- **Conditional field.** The completion check is the card's `read` prop — it renders only for read chapters and is inert on every other card. The chapter number sits in the `eyebrow`. The course hub always renders as a list.
- **Cross-variant fixes.** The cards also use the `borderless` variant, whose rules previously lost to the Library's high-specificity scoped CSS. Moving to the shared variant surfaced three conflicts, each fixed with a compound selector so the `list` layout wins:
  - `info` padding (rows stay flush)
  - the check gutter on mobile
  - the row **divider** (`borderless`'s `border: none` was dropping the top border)

## Verification

Built locally and checked with a headless browser:
- Library list view renders identically to before — full-size titles, descriptions, metadata rows, and dividers between rows.
- Course rows match the Library rows exactly (eyebrow number, title, description, read-time).
- Dividers: first row has none, rows 2+ show a 1px rule, on both pages.
- The ✓ renders green, right-aligned and vertically centred in the empty third column, only when a chapter is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn)_