### PR TITLE
Reader: disable enforced pause timer; show session title on every beat

### DIFF
--- a/src/pages/SessionReader.vue
+++ b/src/pages/SessionReader.vue
@@ -2,6 +2,8 @@
   <PageWrapper>
     <GridContainer>
       <div class="session-reader">
+        <h1 v-if="sessionLabel" class="session-reader__title">{{ sessionLabel }}</h1>
+
         <div class="session-reader__beat" :key="index">
           <div
             v-if="currentBeat && currentBeat.text"
@@ -169,15 +171,19 @@ export default {
         clearTimeout(pauseTimer);
         pauseTimer = null;
       }
-      const pause = currentBeat.value?.pause || 0;
-      if (pause > 0) {
-        ready.value = false;
-        pauseTimer = setTimeout(() => {
-          ready.value = true;
-        }, pause * 1000);
-      } else {
-        ready.value = true;
-      }
+      // Enforced pause disabled for now — the timed wait felt too restrictive.
+      // Continue is always available. To bring the enforced pause back, restore
+      // the block below (it holds Continue for the beat's `pause` seconds).
+      ready.value = true;
+      // const pause = currentBeat.value?.pause || 0;
+      // if (pause > 0) {
+      //   ready.value = false;
+      //   pauseTimer = setTimeout(() => {
+      //     ready.value = true;
+      //   }, pause * 1000);
+      // } else {
+      //   ready.value = true;
+      // }
     };
 
     const loadLineForBeat = () => {
@@ -287,6 +293,11 @@ export default {
   margin-inline: auto;
   inline-size: 100%;
   padding-block: var(--spacing-lg) var(--spacing-xl);
+}
+
+.session-reader__title {
+  margin-block-end: var(--spacing-lg);
+  font-weight: var(--fontWeight-bold);
 }
 
 .session-reader__beat {


### PR DESCRIPTION
These two changes were pushed after #222 had already merged, so they were stranded on the branch with no open PR. Rebased onto the latest `main` and opened here.

## Changes (SessionReader only)

- **Enforced pause timer disabled.** The timed wait felt too restrictive, so `applyPause` now leaves Continue always available (no wait, no rest dot). The enforcement block is kept **commented** in place, so it's a one-line uncomment to bring back the timed hold.
- **Session title on every beat.** The title renders persistently above the content ("Session 1 · Arrive"), so each screen shows which session you're in — it was only in the breadcrumb before.

No change to the progress counter: a paced session still counts as one unit (`setChapterRead` fires once on finish).

Verified on a local build: Continue is available immediately on beat 0, and the title persists across beats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn)_