### PR TITLE
Revert Still Yourself session 1 to a normal doc; archive the paced version

### DIFF
--- a/src/assets/_draft_ideas/still-yourself-session-1-paced.md
+++ b/src/assets/_draft_ideas/still-yourself-session-1-paced.md
@@ -1,0 +1,54 @@
+<!--
+  SAVED: paced/reader version of Still Yourself, Session 1.
+  This is the version wired to the SessionReader (/session/:slug), with
+  <!-- silence: N --> and <!-- line: … --> markers driving one-beat-per-screen
+  pacing and the inline write field. The live course currently renders Session 1
+  as a normal doc like the other sessions; to restore the paced experience,
+  copy this back to src/assets/content/still_yourself_1.md and point the
+  manifest route at /session/still-yourself-arrive again.
+-->
+
+# Session 1 · Arrive
+
+Distractions off. Not gone, just quiet and out of your hands for ten minutes. You will not need them.
+
+<!-- silence: 5 -->
+
+Nothing to solve here. Nothing to get right, and no way to fall behind.
+
+Notice where you are. This chair, this room, the air, whatever you can hear right now.
+
+<!-- silence: 10 -->
+
+Take one breath you actually feel. Not deep, not a technique. Just one you notice going in and coming out.
+
+<!-- silence: 10 -->
+
+Now the honest part, the thing that tends to go unsaid at work.
+
+You are good at what you do, and have been for a long time. Lately it has stopped feeling like enough. Something in the field is shifting, and part of you has been braced against it for a while.
+
+The bracing is quiet. From the outside you look fine: still delivering, nobody worried. That is what makes it heavy. You carry it on top of the work, alone, with nothing you could point to if someone asked.
+
+<!-- silence: 10 -->
+
+You might be arguing with me already. It is not that bad. Everyone is dealing with this. I do not have time for this.
+
+Fair enough. See if you can notice the argument instead of settling it. Explaining it away is its own kind of carrying, and you have been doing it a while.
+
+<!-- silence: 10 -->
+
+We are not fixing this today, or tidying it away in six sessions. We are setting it down where you can see it, because you cannot look clearly at something you are carrying on your back.
+
+So, one thing before you go.
+
+Name what you have been bracing against. Plainly. Not the performance-review version. The one you would say to someone you trust, late, when you had stopped managing your face.
+
+One line.
+
+<!-- line: What I have been bracing against -->
+<!-- silence: 20 -->
+
+That line is yours, and nobody sees it. Keep it where you can find it. You will build on it five more times.
+
+That is the first. Carry on whenever you are ready.

--- a/src/assets/data/still-yourself.json
+++ b/src/assets/data/still-yourself.json
@@ -22,7 +22,7 @@
       "title": "Arrive",
       "description": "Name the thing that does not get said out loud at work: the shift you have been braced against for months.",
       "slug": "still-yourself-arrive",
-      "route": "/session/still-yourself-arrive",
+      "route": "/secured/doc/still-yourself-arrive",
       "contentFile": "still_yourself_1.md",
       "published": true
     },


### PR DESCRIPTION
Session 1 was the only chapter wired to the paced `SessionReader`. This puts it back to a normal doc like the other sessions, and saves the paced version so it isn't lost.

## Changes

- **Session 1 route → `/secured/doc/still-yourself-arrive`** in the manifest, so it renders through the standard `MarkdownPage` like sessions 2–7. The invisible `<!-- silence -->` / `<!-- line -->` markers stay in the file and are simply ignored by the normal renderer, so it reads clean.
- **Paced version archived** to `src/assets/_draft_ideas/still-yourself-session-1-paced.md`, with a header note on how to restore it (copy back to `content/` and repoint the route at `/session/...`).
- The `SessionReader` component and `/session/:slug` route stay in the codebase — just unused by the live course for now, so re-enabling is a route flip.

## Verified (local build)

- Hub's Session 1 card links to `/secured/doc/still-yourself-arrive`.
- That page renders via `MarkdownPage` (not the reader), with the title + byline, and no visible markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_015giYRJwgduvsa5xjE4G7Bn)_