### PR TITLE
Wire newsletter form to Buttondown and render it site-wide

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,13 @@ transform: rotate(90deg);
         />
       </template>
     </StickyNav> -->
-    <!-- <NewsletterSubscription /> -->
+    <section
+      v-if="!$route.meta.hideFooter"
+      class="newsletter-band"
+      aria-label="Subscribe"
+    >
+      <NewsletterSubscription />
+    </section>
     <MainFooter v-if="!$route.meta.hideFooter" />
     <!-- <SimpleFooter v-if="!$route.meta.hideFooter" /> -->
     <!-- <UnderConstructionBar /> -->
@@ -189,6 +195,12 @@ export default {
 
 <style lang="scss">
 @import './assets/styles/css/all.css';
+
+.newsletter-band {
+  display: flex;
+  justify-content: center;
+  padding: var(--spacing-lg) var(--spacing-md);
+}
 
 .slide-enter-from {
   transform: translateX(100%);

--- a/src/components/form/NewsletterSubscription.vue
+++ b/src/components/form/NewsletterSubscription.vue
@@ -1,12 +1,28 @@
 <template>
-  <div>
-    <!-- <img :src="imageSrc" alt="Newsletter Image" /> -->
-    <p>{{ placeholderText }}</p>
-    <input v-model="email" placeholder="Enter your email" />
-    <MyButton label="Subscribe!" size="small" @click="subscribe">Subscribe</MyButton>
+  <div class="newsletter">
+    <p class="newsletter__lead">{{ leadText }}</p>
+    <form class="newsletter__form" @submit.prevent="subscribe">
+      <MyInput
+        id="newsletter-email"
+        type="email"
+        name="email"
+        label="Email address"
+        hide-label
+        placeholder="you@example.com"
+        autocomplete="email"
+        size="small"
+        :submit-button="true"
+        :submit-disabled="submitting"
+        v-model="email"
+        @submit="subscribe"
+      />
+    </form>
     <p
       v-if="message"
-      :class="{ 'success-message': isSuccess, 'error-message': !isSuccess }"
+      class="newsletter__message"
+      :class="{ 'is-success': isSuccess, 'is-error': !isSuccess }"
+      role="status"
+      aria-live="polite"
     >
       {{ message }}
     </p>
@@ -14,43 +30,82 @@
 </template>
 
 <script setup>
-import { ref, onBeforeUnmount } from "vue";
-import { useStore } from "vuex";
+import { ref } from "vue";
 
-const store = useStore();
+// Buttondown embed endpoint for the owned list.
+const ENDPOINT =
+  "https://buttondown.com/api/emails/embed-subscribe/jacquesramphal";
+
+const leadText =
+  "Notes on design when making is cheap and judgment is the scarce skill. I send new essays as I publish them.";
 
 const email = ref("");
+const message = ref("");
+const isSuccess = ref(false);
+const submitting = ref(false);
 
-onBeforeUnmount(() => {
-  store.commit("resetState");
-});
+const isValidEmail = (value) => /\S+@\S+\.\S+/.test(value);
 
-// const imageSrc = "/path/to/your/image/placeholder.jpg";
-const placeholderText = "Subscribe to my Ramblings";
+const subscribe = async () => {
+  const value = email.value.trim();
 
-const subscribe = () => {
-  store.dispatch("subscribe", email.value);
+  if (!isValidEmail(value)) {
+    isSuccess.value = false;
+    message.value = "Please enter a valid email address.";
+    return;
+  }
+
+  submitting.value = true;
+  message.value = "";
+
+  try {
+    await fetch(ENDPOINT, {
+      method: "POST",
+      mode: "no-cors",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ email: value }),
+    });
+    // A no-cors request returns an opaque response, so the status can't be
+    // read. Buttondown sends its own confirmation email; treat the submit as
+    // delivered and point the reader there.
+    isSuccess.value = true;
+    message.value = "Almost there — check your inbox to confirm.";
+    email.value = "";
+  } catch (e) {
+    isSuccess.value = false;
+    message.value = "Something went wrong. Please try again.";
+  } finally {
+    submitting.value = false;
+  }
 };
-
-// eslint-disable-next-line no-unused-vars
-const { email: globalEmail, message, isSuccess } = store.state; // You can use these directly if needed
-
-// const validateEmail = (email) => {
-//   return /\S+@\S+\.\S+/.test(email);
-// };
 </script>
 
-<style>
-.success-message {
-  color: green;
+<style scoped>
+.newsletter {
+  width: 100%;
+  max-width: 32rem;
 }
 
-button {
-  /* position: absolute;
-  margin-inline-start: -140px; */
+.newsletter__lead {
+  margin: 0 0 var(--spacing-xs) 0;
+  font-size: var(--font-400);
+  color: var(--foreground-subtle, var(--foreground));
 }
 
-.error-message {
-  color: red;
+.newsletter__form {
+  width: 100%;
+}
+
+.newsletter__message {
+  margin: var(--spacing-xxs) 0 0 0;
+  font-size: var(--font-300);
+}
+
+.newsletter__message.is-success {
+  color: var(--color-success, green);
+}
+
+.newsletter__message.is-error {
+  color: var(--color-error, red);
 }
 </style>


### PR DESCRIPTION
Replace the simulated Vuex subscribe action with a real POST to the
Buttondown embed endpoint, using the branded MyInput inline-submit field.
Uncomment and place the capture in a band above the footer, shown wherever
the footer shows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ