### PR TITLE
Restyle subscribe band and add thank-you page

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -47,6 +47,7 @@ function collectRoutes() {
     '/resume',
     '/links',
     '/designsystem',
+    '/subscribed',
   ]);
 
   // Article / doc routes from the library registry (prefer human-readable slug).

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,13 +51,7 @@ transform: rotate(90deg);
         />
       </template>
     </StickyNav> -->
-    <section
-      v-if="!$route.meta.hideFooter"
-      class="newsletter-band"
-      aria-label="Subscribe"
-    >
-      <NewsletterSubscription />
-    </section>
+    <NewsletterSubscription v-if="!$route.meta.hideFooter" />
     <MainFooter v-if="!$route.meta.hideFooter" />
     <!-- <SimpleFooter v-if="!$route.meta.hideFooter" /> -->
     <!-- <UnderConstructionBar /> -->
@@ -195,12 +189,6 @@ export default {
 
 <style lang="scss">
 @import './assets/styles/css/all.css';
-
-.newsletter-band {
-  display: flex;
-  justify-content: center;
-  padding: var(--spacing-lg) var(--spacing-md);
-}
 
 .slide-enter-from {
   transform: translateX(100%);

--- a/src/components/form/NewsletterSubscription.vue
+++ b/src/components/form/NewsletterSubscription.vue
@@ -1,32 +1,46 @@
 <template>
-  <div class="newsletter">
-    <p class="newsletter__lead">{{ leadText }}</p>
-    <form class="newsletter__form" @submit.prevent="subscribe">
-      <MyInput
-        id="newsletter-email"
-        type="email"
-        name="email"
-        label="Email address"
-        hide-label
-        placeholder="you@example.com"
-        autocomplete="email"
-        size="small"
-        :submit-button="true"
-        :submit-disabled="submitting"
-        v-model="email"
-        @submit="subscribe"
+  <GridContainer class="newsletter">
+    <form class="newsletter__inner" @submit.prevent="subscribe">
+      <TextBlock
+        center
+        as="h3"
+        title="Subscribe"
+        :description="leadText"
       />
+
+      <div class="newsletter__row">
+        <MyInput
+          id="newsletter-email"
+          type="email"
+          name="email"
+          label="Email address"
+          hide-label
+          placeholder="you@example.com"
+          autocomplete="email"
+          v-model="email"
+        />
+        <MyButton
+          class="newsletter__btn"
+          label="Subscribe"
+          name="submit"
+          primary
+          size="large"
+          :disabled="submitting"
+          @click="subscribe"
+        />
+      </div>
+
+      <p
+        v-if="message"
+        class="newsletter__message"
+        :class="{ 'is-success': isSuccess, 'is-error': !isSuccess }"
+        role="status"
+        aria-live="polite"
+      >
+        {{ message }}
+      </p>
     </form>
-    <p
-      v-if="message"
-      class="newsletter__message"
-      :class="{ 'is-success': isSuccess, 'is-error': !isSuccess }"
-      role="status"
-      aria-live="polite"
-    >
-      {{ message }}
-    </p>
-  </div>
+  </GridContainer>
 </template>
 
 <script setup>
@@ -81,24 +95,30 @@ const subscribe = async () => {
 </script>
 
 <style scoped>
-.newsletter {
+.newsletter__inner {
   width: 100%;
   max-width: 32rem;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.newsletter__lead {
-  margin: 0 0 var(--spacing-xs) 0;
-  font-size: var(--font-400);
-  color: var(--foreground-subtle, var(--foreground));
-}
-
-.newsletter__form {
+.newsletter__row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
   width: 100%;
+  margin-block-start: var(--spacing-sm);
+}
+
+.newsletter__btn {
+  align-self: center;
 }
 
 .newsletter__message {
-  margin: var(--spacing-xxs) 0 0 0;
-  font-size: var(--font-300);
+  margin: var(--spacing-xs) 0 0 0;
+  text-align: center;
 }
 
 .newsletter__message.is-success {

--- a/src/components/form/NewsletterSubscription.vue
+++ b/src/components/form/NewsletterSubscription.vue
@@ -1,46 +1,48 @@
 <template>
-  <GridContainer class="newsletter">
-    <form class="newsletter__inner" @submit.prevent="subscribe">
-      <TextBlock
-        center
-        as="h3"
-        title="Subscribe"
-        :description="leadText"
-      />
-
-      <div class="newsletter__row">
-        <MyInput
-          id="newsletter-email"
-          type="email"
-          name="email"
-          label="Email address"
-          hide-label
-          placeholder="you@example.com"
-          autocomplete="email"
-          v-model="email"
+  <GridWrapper class="newsletter" style="background: var(--background-darker)">
+    <GridContainer>
+      <form class="newsletter__inner" @submit.prevent="subscribe">
+        <TextBlock
+          center
+          as="h2"
+          title="Subscribe"
+          :description="leadText"
         />
-        <MyButton
-          class="newsletter__btn"
-          label="Subscribe"
-          name="submit"
-          primary
-          size="large"
-          :disabled="submitting"
-          @click="subscribe"
-        />
-      </div>
 
-      <p
-        v-if="message"
-        class="newsletter__message"
-        :class="{ 'is-success': isSuccess, 'is-error': !isSuccess }"
-        role="status"
-        aria-live="polite"
-      >
-        {{ message }}
-      </p>
-    </form>
-  </GridContainer>
+        <div class="newsletter__row">
+          <MyInput
+            id="newsletter-email"
+            type="email"
+            name="email"
+            label="Email address"
+            hide-label
+            placeholder="you@example.com"
+            autocomplete="email"
+            v-model="email"
+          />
+          <MyButton
+            class="newsletter__btn"
+            label="Subscribe"
+            name="submit"
+            primary
+            size="large"
+            :disabled="submitting"
+            @click="subscribe"
+          />
+        </div>
+
+        <p
+          v-if="message"
+          class="newsletter__message"
+          :class="{ 'is-success': isSuccess, 'is-error': !isSuccess }"
+          role="status"
+          aria-live="polite"
+        >
+          {{ message }}
+        </p>
+      </form>
+    </GridContainer>
+  </GridWrapper>
 </template>
 
 <script setup>

--- a/src/pages/SubscribedPage.vue
+++ b/src/pages/SubscribedPage.vue
@@ -1,0 +1,47 @@
+<template>
+  <PageWrapper>
+    <GridContainer class="subscribed" fullvh>
+      <div class="subscribed__inner">
+        <TextBlock
+          center
+          as="h1"
+          title="You're on the list."
+          description="Thanks for subscribing. New essays land on the site first, then arrive in your inbox as I publish them."
+        />
+        <div class="subscribed__actions">
+          <MyButton label="Read the writing" primary size="large" route="/writing" />
+          <MyButton label="Back home" type="ghost" size="large" route="/" />
+        </div>
+      </div>
+    </GridContainer>
+  </PageWrapper>
+</template>
+
+<script>
+export default {
+  name: "SubscribedPage",
+};
+</script>
+
+<style scoped>
+.subscribed {
+  align-items: center;
+}
+
+.subscribed__inner {
+  width: 100%;
+  max-width: 40rem;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.subscribed__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  margin-block-start: var(--spacing-lg);
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -19,6 +19,7 @@ import UsefulLinks from '@/pages/UsefulLinks.vue';
 import CoursePage from '@/pages/CoursePage.vue';
 import SessionReader from '@/pages/SessionReader.vue';
 import BusinessCardPage from '@/pages/BusinessCardPage.vue';
+import SubscribedPage from '@/pages/SubscribedPage.vue';
 import FullscreenMenu from '../components/FullscreenMenu.vue';
 import { getDocRecordById } from '@/utils/docRegistry';
 import { getCourseBySlug, getDefaultCourse } from '@/utils/courseRegistry';
@@ -227,6 +228,14 @@ const routes = [
       hideFooter: true,
       hideChat: true,
       dynamicTitle: true,
+    },
+  },
+  {
+    name: 'Subscribed',
+    path: '/subscribed',
+    component: SubscribedPage,
+    meta: {
+      title: 'Subscribed',
     },
   },
   {


### PR DESCRIPTION
Follow-up to #225, which wired the newsletter form to Buttondown and rendered it site-wide. These two commits build on that.

## Changes

**Restyle the subscribe band** — Wrap the newsletter capture in a full-width `GridWrapper` using the `background-darker` token, mirroring the ProductPage section pattern: a centered `TextBlock` title and default-size description over a centered subscribe CTA. Padding comes from `GridContainer`, so it matches every other section.

**Add a branded thank-you page** — New `/subscribed` route ("You're on the list.") for Buttondown to redirect to after a reader confirms their email, with links back to the writing and home. Registered in the router and added to the prerender list so it renders without JavaScript.

## Follow-up (outside this diff)

Set Buttondown's post-confirmation redirect URL to `https://ramphal.design/subscribed` so the thank-you page closes the loop.

## Verification

- `vue-cli-service lint` — clean
- `vue-cli-service build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ)_