### PR TITLE
Refine subscribe row alignment and mobile stacking

### DIFF
--- a/src/components/form/NewsletterSubscription.vue
+++ b/src/components/form/NewsletterSubscription.vue
@@ -118,23 +118,46 @@ const subscribe = async () => {
     grid-row: 1;
     grid-column: 2 / 4;
     align-self: center;
+    /* Drop the container's right padding so the field group fills the
+       column to the band's right edge. */
+    margin-inline-end: calc(-1 * var(--spacing-xl));
   }
 }
 
+/* Mobile: input and button stack, button full width. */
 .newsletter__row {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: var(--spacing-xs);
   width: 100%;
 }
 
-.newsletter__row :deep(#input) {
-  flex: 1 1 16rem;
+.newsletter__btn :deep(.custom-btn) {
+  width: 100%;
 }
 
-.newsletter__btn {
-  flex: 0 0 auto;
+/* Tablet and up: input and button sit in a row, button matches the field
+   height and aligns to its top. */
+@media only screen and (min-width: 768px) {
+  .newsletter__row {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .newsletter__row :deep(#input) {
+    flex: 1 1 auto;
+  }
+
+  .newsletter__btn {
+    flex: 0 0 auto;
+    display: flex;
+  }
+
+  .newsletter__btn :deep(.custom-btn) {
+    width: auto;
+    height: 100%;
+  }
 }
 
 .newsletter__message {


### PR DESCRIPTION
Follow-up to #227. Tightens the input/button row in the subscribe band.

## Changes

- **Remove right-side container padding (desktop):** the form column now fills to the band's right edge instead of stopping at the container's inline padding.
- **Button aligned to the field:** the Subscribe button matches the input's height and aligns to its top (row uses `align-items: stretch`).
- **Mobile stacking:** below 768px the input and button stack, with the button full width.

## Verification

- `vue-cli-service lint` — clean
- `vue-cli-service build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ)_