### PR TITLE
Align subscribe input and button to a shared height

### DIFF
--- a/src/components/form/NewsletterSubscription.vue
+++ b/src/components/form/NewsletterSubscription.vue
@@ -115,17 +115,26 @@ const subscribe = async () => {
   width: 100%;
 }
 
-/* Tablet and up: input and button sit in a row, button matches the field
-   height and aligns to its top. */
+/* Tablet and up: input and button sit in a row at one shared height, so the
+   button matches the field height and their tops and bottoms line up. */
 @media only screen and (min-width: 768px) {
   .newsletter__row {
     flex-direction: row;
-    flex-wrap: wrap;
-    align-items: stretch;
+    flex-wrap: nowrap;
+    align-items: center;
   }
 
   .newsletter__row :deep(#input) {
     flex: 1 1 12rem;
+  }
+
+  .newsletter__row :deep(.input-wrap) {
+    height: auto;
+  }
+
+  .newsletter__row :deep(input) {
+    height: var(--size-10);
+    box-sizing: border-box;
   }
 
   .newsletter__btn {
@@ -135,7 +144,12 @@ const subscribe = async () => {
 
   .newsletter__btn :deep(.custom-btn) {
     width: auto;
-    height: 100%;
+    height: var(--size-10);
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-block: 0;
   }
 }
 


### PR DESCRIPTION
Fixes the input/button height mismatch in the subscribe band.

## Cause

The button couldn't resolve `height: 100%` against a stretched flex item (and `.custom-btn` isn't a flex box with fixed vertical padding), so it kept its shorter natural height while the input rendered taller.

## Fix

- Give the input element and the button one explicit shared height (`--size-10`) on tablet and up, with `box-sizing: border-box`.
- Make the button an inline-flex box so its label centers within the fixed height.
- Mobile still stacks the input and full-width button.

## Verification

- `vue-cli-service lint` — clean
- `vue-cli-service build` — succeeds
- Rendered and screenshotted at desktop (1440px) and mobile (390px): input and button now match height and align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ)_