### PR TITLE
Move the subscribe capture into the global footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,6 @@ transform: rotate(90deg);
         />
       </template>
     </StickyNav> -->
-    <NewsletterSubscription v-if="!$route.meta.hideFooter" />
     <MainFooter v-if="!$route.meta.hideFooter" />
     <!-- <SimpleFooter v-if="!$route.meta.hideFooter" /> -->
     <!-- <UnderConstructionBar /> -->

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -32,6 +32,10 @@
                 title="Jacques Ramphal"
                 description="I lead design work where systems, code, and AI meet—building the practices and platforms that let cross-functional teams deliver meaningful products efficiently and sustainably."
               />
+              <div class="footer-subscribe">
+                <p class="subtle">Subscribe</p>
+                <SubscribeForm />
+              </div>
             </div>
             <GridParent tight id="content">
               <div id="links1">
@@ -159,6 +163,7 @@ import GridWrapper from './grid/GridWrapper.vue';
 import TextBlock from './text/TextBlock/TextBlock.vue';
 import TextLink from './text/TextLink.vue';
 import GridParent from './grid/GridParent.vue';
+import SubscribeForm from './form/SubscribeForm.vue';
 // import TextArea from "@/components/form/TextArea.vue";
 // import MyButton from "@/components/Button/Button.vue";
 
@@ -170,6 +175,7 @@ export default {
     TextBlock,
     TextLink,
     GridParent,
+    SubscribeForm,
   },
   props: {
     title: {
@@ -424,6 +430,15 @@ li {
 #maindetails {
   @media only screen and (min-width: 768px) {
     padding-inline-end: var(--spacing-md);
+  }
+}
+
+.footer-subscribe {
+  margin-block-start: var(--spacing-md);
+  max-inline-size: 22rem;
+
+  .subtle {
+    margin-block-end: var(--spacing-xxs);
   }
 }
 #content {

--- a/src/components/form/SubscribeForm.vue
+++ b/src/components/form/SubscribeForm.vue
@@ -1,0 +1,110 @@
+<template>
+  <form class="subscribe" @submit.prevent="subscribe">
+    <div class="subscribe__row">
+      <MyInput
+        id="subscribe-email"
+        type="email"
+        name="email"
+        label="Email address"
+        hide-label
+        placeholder="you@example.com"
+        autocomplete="email"
+        v-model="email"
+      />
+      <MyButton
+        class="subscribe__btn"
+        label="Subscribe"
+        name="submit"
+        primary
+        :disabled="submitting"
+        @click="subscribe"
+      />
+    </div>
+
+    <p
+      v-if="message"
+      class="subscribe__message"
+      :class="{ 'is-success': isSuccess, 'is-error': !isSuccess }"
+      role="status"
+      aria-live="polite"
+    >
+      {{ message }}
+    </p>
+  </form>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// Buttondown embed endpoint for the owned list.
+const ENDPOINT =
+  "https://buttondown.com/api/emails/embed-subscribe/jacquesramphal";
+
+const email = ref("");
+const message = ref("");
+const isSuccess = ref(false);
+const submitting = ref(false);
+
+const isValidEmail = (value) => /\S+@\S+\.\S+/.test(value);
+
+const subscribe = async () => {
+  const value = email.value.trim();
+
+  if (!isValidEmail(value)) {
+    isSuccess.value = false;
+    message.value = "Please enter a valid email address.";
+    return;
+  }
+
+  submitting.value = true;
+  message.value = "";
+
+  try {
+    await fetch(ENDPOINT, {
+      method: "POST",
+      mode: "no-cors",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ email: value }),
+    });
+    // A no-cors request returns an opaque response, so the status can't be
+    // read. Buttondown sends its own confirmation email; treat the submit as
+    // delivered and point the reader there.
+    isSuccess.value = true;
+    message.value = "Almost there — check your inbox to confirm.";
+    email.value = "";
+  } catch (e) {
+    isSuccess.value = false;
+    message.value = "Something went wrong. Please try again.";
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<style scoped>
+/* Full-width field with the Subscribe button below it at its natural width.
+   Heights use each component's own defaults. */
+.subscribe__row {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--spacing-xs);
+  width: 100%;
+}
+
+.subscribe__btn {
+  align-self: flex-start;
+}
+
+.subscribe__message {
+  margin: var(--spacing-xs) 0 0 0;
+}
+
+.subscribe__message.is-success {
+  color: var(--color-success, green);
+}
+
+.subscribe__message.is-error {
+  color: var(--color-error, red);
+}
+</style>


### PR DESCRIPTION
Implements the recommendation to fold the newsletter capture into the footer rather than keep a repeated standalone band.

## Changes

- **New `SubscribeForm` component** — extracts the Buttondown form (field + button + inline confirmation) into one reusable piece.
- **Footer capture** — placed in `MainFooter` under the name and bio, so subscribe is present site-wide (wherever the footer shows) without a separate heavy band. The "Subscribe" label matches the other footer column headers.
- **Removed the standalone band** from the app shell (`App.vue`).

## Rationale

A footer column would bury the capture (the audit's "capture buried" = weak Invitation). Sitting under the bio, it reads as a natural "here's who I am → follow along," and it stops the image-split band from repeating on every page. The prominent image-split version is reserved for a per-essay CTA (next PR).

## Notes

- The image-split `NewsletterSubscription` is left untouched on `main` (no longer rendered globally); it'll be refactored onto `SubscribeForm` and wired as the per-essay CTA in the follow-up.

## Verification

- `vue-cli-service lint` — clean
- `vue-cli-service build` — succeeds
- Rendered and screenshotted footer at desktop (1440px) and mobile (390px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ