### PR TITLE
Fix course breadcrumb trail

### DIFF
--- a/src/components/BreadCrumb.vue
+++ b/src/components/BreadCrumb.vue
@@ -37,10 +37,20 @@
         route="/library"
         v-show="isDesktopScreen"
       />
+      <router-link
+        v-else-if="courseHub"
+        :to="$route.path"
+        class="nav-item"
+        active-class="active"
+        exact
+        v-show="isDesktopScreen"
+      >
+        {{ courseHub.title }}
+      </router-link>
 
       <template v-if="isProjectOrDoc">
         <DynamicText
-          v-if="isLibraryOrDeeper"
+          v-if="isLibraryOrDeeper || courseContext"
           v-show="isDesktopScreen"
           :as="p"
           text="/"
@@ -65,7 +75,7 @@ import workData from '../assets/data/work.json';
 import DynamicText from '../components/text/DynamicText.vue';
 import TextLink from '../components/text/TextLink.vue';
 import { getDocRecordById, isNumericRouteParam } from '@/utils/docRegistry';
-import { getChapterContext } from '@/utils/courseRegistry';
+import { getChapterContext, getCourseBySlug, getDefaultCourse } from '@/utils/courseRegistry';
 export default {
   name: 'BreadCrumb',
   components: { DynamicText, TextLink },
@@ -115,6 +125,14 @@ export default {
       }
 
       return slug ? getChapterContext(slug) : null;
+    },
+    // On a course hub page (/course or /course/:slug), resolve the course so it
+    // shows as the current crumb (Home / Course Title).
+    courseHub() {
+      const path = (this.$route?.path || '').toLowerCase();
+      if (!path.startsWith('/course')) return null;
+      const slug = (this.$route.params.slug || '').toString().trim();
+      return slug ? getCourseBySlug(slug) : getDefaultCourse();
     },
   },
   async created() {


### PR DESCRIPTION
Breadcrumb-only patch (stripped the chat-copy, chapter-nav font, and rules-doc changes so nothing else on `main` is overridden).

## Changes (`BreadCrumb.vue` only)

- **Missing separator:** the `/` before the chapter title now renders whenever a course crumb precedes it, so `/session` and `/secured/doc` chapters keep the slash (e.g. "Still Yourself Arrive" → "Still Yourself / Arrive").
- **Hub not in breadcrumb:** the course hub (`/course`, `/course/:slug`) now shows the course as the current crumb ("Jacques Ramphal / Still Yourself") instead of a dangling separator.

## Verification

- `vue-cli-service lint` — clean
- `vue-cli-service build` — succeeds
- Rendered from the branch: hub, `/secured/doc` chapter (slash present), all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ