### PR TITLE
Add /hire alternate homepage, résumé CTA, career Q&A, and planning notes

### DIFF
--- a/docs/plans/career-and-monetization-notes.md
+++ b/docs/plans/career-and-monetization-notes.md
@@ -76,4 +76,37 @@ Honest synthesis (to pressure-test, not conclude):
 - Fix immediate hygiene if keeping it: routing, `/doc/process` links, remove Orium-colleague testimonials from any live version.
 - Consider one low-maintenance, marketplace-distributed product (Figma plugin) as brand-builder + proof — not as the money plan.
 
+---
+
+## Industry context & timing
+
+The design market has been contracting since the 2022 peak and hasn't recovered. Three forces:
+- **Employer's market.** Design gets cut first (read as a cost center). Fewer openings, more applicants, longer searches, comp compressed off the 2021 highs.
+- **AI is compressing the execution layer** — mockups, variations, front-end scaffolding. The pure-Figma-execution role is devaluing; the mid-level IC tier is hollowing out fastest.
+- **Bifurcation.** Commodity execution (automated/offshored) vs. high-judgment systems/strategy/design-engineering (AI makes it *more* valuable). Teams flatten; companies want fewer, more capable people with AI leverage.
+
+Implications for me:
+- **My combo (design + production code + agents) is on the resilient side** — but only cashes in for design-engineering / systems / AI roles. Presenting as a generic senior product designer = the glutted pool.
+- **The big external jump is harder now**, not easier (buyer's market). → reinforces leverage-in-place over leaping.
+- **Safety instinct is validated by the climate** — but **Orium's safety has an asterisk**: services/consultancies are squeezed by client budget cuts + AI eating billable hours. Tenure protects my seat relative to peers, not against a team/company-level contraction. "Safe, lower pay" may be optimistic.
+- **My edge is scarce *now* and may erode** as tooling matures and more people cross-skill (my own "Taste is Triage" thesis). Leverage is near its peak — sitting on it has a cost.
+
+Net: the climate **strengthens** leverage-in-place + build-optionality and **weakens** both quit-and-chase-a-jump and the solo offering (which sells into a contracting, AI-compressed design-services market). But it adds urgency: don't idle the scarce positioning.
+
+Hard reframe: "long-tenured designer at a consultancy, validated only internally, no external presence" is a *comfortable* position in an AI-compressed services market, not a *safe* one. The gap between comfortable and safe is exactly the optionality not yet built.
+
+---
+
+## Recommended path (sequenced)
+
+**Thesis:** monetize the scarce positioning while it's scarce — primarily by repricing/expanding scope inside Orium — while building external optionality as insurance. Don't gamble the secure base on a leap into a soft market; don't idle a time-sensitive edge either.
+
+1. **Price discovery (weeks).** Apply to ~5 *narrowly-targeted* roles (design engineering / systems / AI-native — never generic product design) and take ~2 interviews. Goal: learn the real market number. Not a commitment to leave.
+2. **Understand the base.** Get clarity on equity (value, vesting, cliff, plausible exit) and the internal comp/scope ceiling. Separate the comp cap (likely real) from the role/scope cap (maybe not).
+3. **Leverage in place.** Use the external number + the Genie/agent case to reprice or expand the role at Orium (e.g., a Head of Design Engineering / IP-ownership mandate). Keep tenure, equity, safety.
+4. **Build portable optionality (ongoing).** A little external presence so safety isn't single-sourced: publish the AI/design-engineering writing where it's seen, be findable, keep a live network. This is the insurance the services squeeze demands.
+5. **Fallback, not goal:** if Orium won't move on comp/scope when shown real leverage, the cap is proven — and a targeted external move becomes the plan, now backed by evidence.
+
+Positioning that supports all of the above: everywhere, signal **AI-native design engineer who owns the judgment layer** (the resilient tier), and demote the generic-senior-product-designer signal. See the site positioning audit.
+
 *(End of current notes — WIP.)*

--- a/docs/plans/career-and-monetization-notes.md
+++ b/docs/plans/career-and-monetization-notes.md
@@ -1,0 +1,79 @@
+# Career & Monetization — Planning Notes
+
+> **Status: WORK IN PROGRESS. Draft, not finished. Personal planning — not site content, not registered in `library.json`, not rendered.**
+>
+> Note: this file lives in the repo. If the repo is public, the file is visible in source even though it never appears on the site. Keep that in mind before adding anything you wouldn't want read.
+
+The question driving this: how to make meaningful money from work beyond the Orium salary — weighed honestly against safety, security, tenure, and equity. Below is the current thinking. Verdicts are provisional.
+
+---
+
+## Paths evaluated
+
+### 1. Solo offering / productized audit (the Studio), off-hours
+- Low risk *because* it's additive to the salary; downside is mostly time.
+- Real ceiling problem: distribution. No funnel, no external presence, network concentrated inside one company. Off-hours capacity is small.
+- Realistic outcome: supplemental income (low tens of thousands in a good year, optimistic), not life-changing. Viable as a side experiment, weak as a wealth path.
+
+### 2. Higher-comp role (interview / move)
+- Biggest and most reliable financial delta (a permanent baseline reset, especially US-remote), and it plays to the strength (the work + the proof) rather than the weakness (sales/distribution).
+- Qualifies for a band of roles; a stretch for the top tier. Liabilities on paper: one-company tenure, agency (not product) background, no external presence. (See the tenure reconsideration below — this framing needs nuance.)
+- Correction to earlier: comp target was overstated. Toronto full-time ≈ CAD 170–250k for the profile; US-remote ≈ USD 200–320k; 400k+ is top-of-band/manager, not median.
+
+### 3. Low-maintenance product / tool
+- "Doesn't need my time post-build" is mostly a myth: time moves from delivery to distribution, and without distribution revenue trends to zero.
+- Only viable shape for someone without an audience: a product that rides a marketplace supplying its own traffic. Best fit = a Figma Community plugin/kit in tokens/design systems.
+- Honest ceiling: hundreds to low-thousands/month if it hits; most make ~zero. Treat as brand-builder + small income + interview proof, not the money plan. Rule out SaaS (highest ongoing time, opposite of the goal).
+
+### 4. AI-driven, more-automated studio (less hands-on)
+- Automation optimizes delivery — the part that was never the bottleneck. Leaves distribution (the real constraint) untouched.
+- The part it can't automate (the human judgment gates) is both the value and the time floor. Remove it and you're reselling raw AI output; keep it and time-per-engagement has a floor.
+- In practice the pipeline becomes the maintenance (brittle, per-client, non-deterministic). Not "passive."
+- **Where it actually pays: as an internal margin lever on a small offering, and — more importantly — as Genie-part-two, a proof artifact for the high-comp role.** Aim it at proof, not at being the business.
+
+---
+
+## Studio audit (this portfolio repo)
+
+- **The Studio page (`src/pages/StudioPage.vue`) is not routed.** No `/studio` route, not linked or imported anywhere → currently unreachable. Decide: publish or delete; don't leave a half-built competing-business page sitting around.
+- **Broken CTAs:** "See/Read the process →" point to `/doc/process`, which has no doc and no `library.json` entry → NotFound.
+- **Automation claims vs. this repo:** the page asserts an "agent team / agent infrastructure." **Correction: the agents live in a separate repo** — so the capability may exist; it just isn't substantiated *here*. For a proof artifact, the evidence needs surfacing/linking; for a sales page, claims without visible proof read as bluster.
+- **Testimonials:** the page reuses the site-wide `quotes.json` carousel. Those are real recommendations but mostly **Orium colleagues** praising demeanor/presentations, not the studio or client outcomes. On a page for an independent, Orium-adjacent studio, that is off-target and a conflict landmine. Must come off any live version.
+- **Pricing** quotes fixed fees to deploy/operate a "validation system" — make sure that maps to something real before it's public.
+
+### Reframe: Studio as proof artifact, not business
+Flip it from *offer* to *evidence*. Show the pipeline architecture, where the human gate sits, one real input→output example. Cut pricing/engagement-model/sales framing. Make the automation claim demonstrably true (link the other repo, show a worked example). The value is the artifact that helps land the role, not the storefront.
+
+---
+
+## Tenure / "lifer" reconsideration  *(open — the earlier "liability" framing was too glib)*
+
+Points raised that deserve weight:
+- **Tenure has kept me relatively safe.** Observed: at some orgs (e.g. Shopify recession cuts) it was closer to last-in-first-out; job-hoppers went first. Long tenure + institutional knowledge + relationships = more embedded, more trusted, harder to cut.
+- **Pay is lower, but safer.** Explicit tradeoff. Safety and security genuinely matter and were under-weighted in the "bunch of money" framing.
+- **I'm a shareholder now.** Real upside optionality that leaving could forfeit or under-realize. Changes the math.
+- **Job-hopping looks bad too.** Serial short stints read as flight risk and get cut first in downturns.
+
+Honest synthesis (to pressure-test, not conclude):
+- Being long-tenured is **broadly an asset**, not a liability. The "liability" only bites in one narrow scenario: elite *product-company* hiring committees screening a specific profile. For most of the market — and for trusted-advisor / leadership roles — long tenure reads as loyalty, depth, reliability.
+- The real risk isn't tenure. It's **concentration**: strong *internal* safety, near-zero *external* optionality. Income, equity, reputation, and network all in one basket. That feels stable right up until it's binary.
+- The Shopify lesson is not "tenure is safe." It's "**don't rely solely on one company.**" The people who recovered fastest from those cuts had portable safety — external reputation and network. Tenure doesn't prevent a layoff; external optionality makes recovery fast. I have the first kind of safety and not the second.
+- So the sharpest move may not be leaving at all. It may be **leverage-in-place + optionality:** get external market validation (interview even without intending to jump) to (a) know my real price and (b) use it to reprice/expand scope internally, while keeping tenure, equity, and safety — and separately build a little external presence so I'm not fragile.
+
+### Open questions that actually decide this
+- **Equity:** realistic value, vesting schedule/cliff, and plausible exit (services companies get lower multiples than SaaS — don't overweight as guaranteed money). What do I forfeit by leaving, and when?
+- **Am I capped at Orium?** Two caps to separate: *comp* cap (likely yes) and *role/scope* cap (is there a path to Head of Design Eng / a bigger internal mandate, and is it actually available?).
+- **Can tenure + Genie + the agent work be leveraged *internally*** into more money/scope/equity, using external offers as leverage — instead of leaving?
+- **Conflict/IP:** what the employment agreement actually allows re: the offering and the tooling.
+- **Definitions:** what is "enough money" and "enough safety" to me, concretely? And do I even *want* founder/sales work, or was that never the point?
+
+---
+
+## Not-yet-decided next steps (candidates, not commitments)
+- Apply to ~5 stretch roles and take ~2 interviews — as **price discovery + leverage**, not necessarily to jump.
+- Get clarity on equity value/vesting and the internal growth/comp ceiling at Orium.
+- Decide the Studio's fate: kill the page, or rebuild it as a proof case study (architecture + gate + one worked example, other repo linked).
+- Fix immediate hygiene if keeping it: routing, `/doc/process` links, remove Orium-colleague testimonials from any live version.
+- Consider one low-maintenance, marketplace-distributed product (Figma plugin) as brand-builder + proof — not as the money plan.
+
+*(End of current notes — WIP.)*

--- a/src/assets/content/doc_30.md
+++ b/src/assets/content/doc_30.md
@@ -201,3 +201,29 @@ Those things aren’t separate from delivery quality; they’re a precondition f
 </span>
 
 
+
+## Career
+
+<span>
+<details>
+<summary>Why have you spent so long at one company?</summary>
+
+The honest answer is the job kept changing faster than leaving could have changed it. I started as a product designer, ended up writing the production front-end, and for the last stretch I’ve been building an agentic platform and defining how designers work with agents. I got handed the next hard problem every year or two without switching companies to find it.
+
+Because the company is a consultancy, the range came built in. Retail, healthcare, commerce, a different codebase and a different constraint on every engagement. It was dozens of contexts, not one.
+
+What’s changed is that I’ve taken that arc about as far as it goes inside a services company. The work I want now is owning a product surface over years rather than shipping and handing it off, and that’s the one thing the model there can’t give me.
+</details>
+
+<details>
+<summary>You’ve mostly done agency work. Can you own a product?</summary>
+
+It’s a fair thing to test, because agency work and product work are different. Client work is ship-and-hand-off: you solve it, you leave, someone else lives with it. So the real question is whether I can live with a surface over time.
+
+The clearest evidence is Genie. Nobody briefed it. I built it as an internal product, shipped it, watched a team use it, and kept changing it based on how they used it rather than a client deadline. The token pipeline and the design tooling I maintain are the same: long-lived internal products with real users that I still own.
+
+The muscle that question worries about is the one I’ve built on everything that wasn’t client work. I want a role where that’s the whole job instead of the side of it.
+</details>
+</span>
+
+

--- a/src/components/FullscreenMenu.vue
+++ b/src/components/FullscreenMenu.vue
@@ -58,7 +58,6 @@ export default {
         { text: 'Home', route: '/' },
         { text: 'Library', route: '/library' },
         { text: 'Resume', route: '/resume.html', external: true },
-        { text: 'FAQs', route: '/doc/ask-me-anything' },
         { text: 'Storybook', route: '/storybook/', external: true },
       ],
     };

--- a/src/components/HeroBanner/HeroBanner.vue
+++ b/src/components/HeroBanner/HeroBanner.vue
@@ -55,16 +55,16 @@
                   v-if="label"
                   size="large"
                   :label="`${label}`"
-                  :route="`${route}`"
-                  :link="`${link}`"
+                  :route="route"
+                  :link="link"
                 />
                 <MyButton
                   v-if="labeltwo"
                   type="outline"
                   size="large"
                   :label="`${labeltwo}`"
-                  :route="`${routetwo}`"
-                  :link="`${linktwo}`"
+                  :route="routetwo"
+                  :link="linktwo"
                 />
               </div>
             </div>

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -198,7 +198,6 @@ export default {
       menuItems3: [
         { text: 'Journal', route: '/doc/design-learnings' },
         { text: 'About', route: '/about' },
-        { text: 'Ask Me Anything', route: '/doc/ask-me-anything' },
         { text: 'AI Ethics', route: '/doc/ai-ethics' },
         { text: 'Privacy', route: '/doc/privacy' },
         { text: 'Accessibility', route: '/doc/accessibility' },

--- a/src/pages/HirePage.vue
+++ b/src/pages/HirePage.vue
@@ -6,10 +6,10 @@
       eyebrow="Design Engineer · Toronto"
       title="I design systems and write the production code that ships them."
       subtitle="I work at the seam between design and engineering: token-based design systems in Figma, the front-end that renders them in React and Vue, and the AI tooling that keeps the two in sync. I build so design decisions survive handoff instead of dying in it."
-      label="Résumé"
-      routetwo="/about"
+      label="Download résumé"
+      link="/resume.html"
       labeltwo="More about me →"
-      route="/resume"
+      routetwo="/about"
       as="h1"
     />
 

--- a/src/pages/HirePage.vue
+++ b/src/pages/HirePage.vue
@@ -1,0 +1,250 @@
+<template>
+  <PageWrapper>
+
+    <!-- HERO -->
+    <HeroBanner
+      eyebrow="Design Engineer · Toronto"
+      title="I design systems and write the production code that ships them."
+      subtitle="I work at the seam between design and engineering: token-based design systems in Figma, the front-end that renders them in React and Vue, and the AI tooling that keeps the two in sync. I build so design decisions survive handoff instead of dying in it."
+      label="Résumé"
+      routetwo="/about"
+      labeltwo="More about me →"
+      route="/resume"
+      as="h1"
+    />
+
+    <!-- SELECTED PROOF -->
+    <GridWrapper>
+      <GridContainer>
+        <GridParent rows>
+          <TextBlock
+            eyebrow="Selected proof"
+            as="h2"
+            title="What I've built."
+            description="Each of these shipped and stayed in use. The case studies show the thinking behind the decisions."
+          />
+          <GridParent>
+            <router-link to="/doc/designing-genie" class="proof-card">
+              <span class="proof-tag proof-tag--lead">Owned end to end</span>
+              <TextBlock
+                as="h3"
+                title="Genie — agentic delivery platform"
+                description="Built from architecture to front-end, including the n8n automation and the UX patterns for how people and agents share the work. It gave the delivery team hours back on routine work, and the patterns it set are used across teams now."
+              />
+              <span class="proof-link">Read the case study →</span>
+            </router-link>
+            <router-link to="/doc/the-design-command-suite" class="proof-card">
+              <span class="proof-tag">Design engineering</span>
+              <TextBlock
+                as="h3"
+                title="The /design environment"
+                description="An isolated, AI-driven Storybook a designer spins up with one command, wired to the same tokens and components as production. It turned handoff from a document someone interprets into a diff a developer merges."
+              />
+              <span class="proof-link">Read the case study →</span>
+            </router-link>
+            <router-link to="/doc/hmi-design-token-pipeline" class="proof-card">
+              <span class="proof-tag">Design systems</span>
+              <TextBlock
+                as="h3"
+                title="Multi-brand token pipeline"
+                description="A single token architecture and a CI lint that held Figma, code, and AI output in line across four brands, two themes, and two modalities."
+              />
+              <span class="proof-link">Read the case study →</span>
+            </router-link>
+            <router-link to="/work" class="proof-card">
+              <span class="proof-tag">Shipped at scale</span>
+              <TextBlock
+                as="h3"
+                title="Customer-facing products"
+                description="Commerce, loyalty, and healthcare platforms used by hundreds of thousands to millions of people, across enterprise and consumer teams."
+              />
+              <span class="proof-link">See the work →</span>
+            </router-link>
+          </GridParent>
+        </GridParent>
+      </GridContainer>
+    </GridWrapper>
+
+    <!-- WHAT I DO -->
+    <div class="section--dark reversed">
+      <GridContainer>
+        <GridParent rows>
+          <TextBlock
+            eyebrow="What I do"
+            as="h2"
+            title="Design and code, held together."
+            description="The rare part isn't any one of these. It's holding the full span, from the token to the production component to the workflow that keeps them aligned."
+          />
+          <GridParent :cols="4">
+            <TextBlock
+              as="h4"
+              title="Design systems & tokens"
+              description="Token architectures that stay in sync across Figma, code, and AI tooling, governed so they don't decay under pressure."
+            />
+            <TextBlock
+              as="h4"
+              title="Production front-end"
+              description="React, Vue, and TypeScript. I write the code that ships the design, so intent maps to what renders."
+            />
+            <TextBlock
+              as="h4"
+              title="Agentic tooling"
+              description="Agent workflows and internal tools that automate the mechanical parts of delivery and keep people in control of the judgment calls."
+            />
+            <TextBlock
+              as="h4"
+              title="Design quality"
+              description="Accessible, high-fidelity UI and the QA systems that hold the line as teams and tools scale."
+            />
+          </GridParent>
+        </GridParent>
+      </GridContainer>
+    </div>
+
+    <!-- EVIDENCE -->
+    <GridWrapper>
+      <GridContainer>
+        <GridParent rows>
+          <TextBlock
+            eyebrow="The evidence"
+            as="h2"
+            title="The site is the argument."
+            description="I built it, the source is public, and the case studies explain the decisions. A designer who writes production code is easy to claim. This is the proof."
+          />
+          <GridParent>
+            <TextBlock
+              as="h4"
+              title="Built and maintained by me"
+              description="Vue 3, TypeScript, token-based theming, no CMS. The front-end you're reading is the front-end I write."
+            />
+            <TextBlock
+              as="h4"
+              title="Open source"
+              description="Design tooling published to npm and GitHub, documented and in use beyond this site."
+            />
+            <TextBlock
+              as="h4"
+              title="Written down"
+              description="Case studies and essays on design systems, agentic craft, and design-to-development, because if I can't explain it I don't understand it yet."
+            />
+          </GridParent>
+        </GridParent>
+      </GridContainer>
+    </GridWrapper>
+
+    <!-- CTA -->
+    <HeroBanner
+      center
+      background
+      as="h2"
+      title="Let's talk."
+      subtitle="Open to design engineering and design systems roles. The fastest way to reach me is email."
+      label="Email"
+      link="mailto:jacques@ramphal.design"
+      labeltwo="View résumé →"
+      routetwo="/resume"
+    />
+
+  </PageWrapper>
+</template>
+
+<script>
+import PageWrapper from '@/components/grid/PageWrapper.vue';
+import HeroBanner from '@/components/HeroBanner/HeroBanner.vue';
+import GridWrapper from '@/components/grid/GridWrapper.vue';
+import GridContainer from '@/components/grid/GridContainer.vue';
+import GridParent from '@/components/grid/GridParent.vue';
+import TextBlock from '@/components/text/TextBlock/TextBlock.vue';
+import { useHead } from '@vueuse/head';
+import { yearsOfExperience } from '@/utils/experience';
+
+export default {
+  name: 'HirePage',
+  components: {
+    PageWrapper,
+    HeroBanner,
+    GridWrapper,
+    GridContainer,
+    GridParent,
+    TextBlock,
+  },
+  setup() {
+    const years = yearsOfExperience();
+    const description = `Design engineer in Toronto with ${years}+ years at the seam between design and engineering. Token-based design systems, production front-end in React and Vue, and agentic tooling.`;
+    useHead({
+      title: 'Jacques Ramphal — Design Engineer',
+      meta: [
+        { name: 'description', content: description },
+        { property: 'og:title', content: 'Jacques Ramphal — Design Engineer' },
+        { property: 'og:description', content: description },
+        { property: 'og:type', content: 'profile' },
+        { property: 'og:url', content: 'https://ramphal.design/hire' },
+        { property: 'twitter:card', content: 'summary_large_image' },
+        { property: 'twitter:title', content: 'Jacques Ramphal — Design Engineer' },
+        { property: 'twitter:description', content: description },
+      ],
+    });
+  },
+  computed: {
+    careerYears() {
+      return yearsOfExperience();
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+/* ── DARK SECTIONS ──────────────────────────────── */
+.section--dark {
+  background: var(--foreground);
+
+  :deep(.subtle) {
+    color: rgba(var(--color-offwhite-rgb), 0.5);
+  }
+}
+
+/* ── PROOF CARDS ────────────────────────────────── */
+.proof-card {
+  border: var(--border);
+  border-radius: var(--spacing-xxs);
+  padding: var(--spacing-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+
+  &:hover {
+    border-color: var(--foreground);
+
+    .proof-link {
+      color: var(--foreground);
+    }
+  }
+}
+
+.proof-tag {
+  display: inline-block;
+  padding: 0.3rem 0.9rem;
+  border-radius: 9999px;
+  font-size: var(--font-2xs);
+  font-weight: var(--fontWeight-semibold);
+  background: var(--background-darker);
+  color: var(--foreground-muted);
+  align-self: flex-start;
+}
+
+.proof-tag--lead {
+  background: var(--foreground);
+  color: var(--background);
+}
+
+.proof-link {
+  margin-top: auto;
+  font-size: var(--font-xs);
+  font-weight: var(--fontWeight-semibold);
+  color: var(--foreground-muted);
+  transition: color 0.15s;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,6 +17,7 @@ import WorkIndex from '@/pages/WorkIndex.vue';
 import PlayIndex from '@/pages/PlayIndex.vue';
 import UsefulLinks from '@/pages/UsefulLinks.vue';
 import CoursePage from '@/pages/CoursePage.vue';
+import HirePage from '@/pages/HirePage.vue';
 import SessionReader from '@/pages/SessionReader.vue';
 import BusinessCardPage from '@/pages/BusinessCardPage.vue';
 import SubscribedPage from '@/pages/SubscribedPage.vue';
@@ -78,6 +79,15 @@ const routes = [
     children: [],
     meta: {
       hideNav: false,
+    },
+  },
+
+  {
+    path: '/hire',
+    name: 'Hire',
+    component: HirePage,
+    meta: {
+      title: 'Jacques Ramphal — Design Engineer',
     },
   },
 


### PR DESCRIPTION
## Summary

A hire-facing alternate homepage plus supporting changes. The record homepage at `/` is unchanged.

### New `/hire` page
- `src/pages/HirePage.vue` — a hire-facing landing page that front-loads capability, proof, and contact for a recruiter or hiring manager scanning quickly. Built from the existing page components and design system (mirrors `StudioPage.vue`), theme-aware. Registered at `/hire`, intentionally **unlisted** (no nav/menu/footer link) so it's a link you send, separate from the public record site.
- Sections: hero (design-engineer positioning), Selected Proof (Genie, /design environment, token pipeline, shipped-at-scale — each linking to its case study), What I Do, The Evidence, and a contact CTA.

### Résumé download
- Hire page hero's primary CTA now points at the print-ready `public/resume.html`.

### HeroBanner fix
- `HeroBanner.vue` was stringifying an undefined `route`/`link` to the literal `"undefined"`, which made link-only buttons render a broken router-link instead of an anchor. Fixed at the source; this also repairs the mailto buttons on the Studio page.

### Ask Me Anything
- Added two career-facing Q&A entries (tenure at one company; agency vs. product ownership) to `doc_30.md`.
- Removed the public links to the page from the footer and fullscreen menu so it stays reachable by direct URL only.

### Planning notes
- `docs/plans/career-and-monetization-notes.md` — WIP strategy notes (not site content, not rendered).

## Notes
- Lint passes on all changed files.
- No PR was requested to be merged; this is to preview the `/hire` page and review the changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017TTWdYXq2dmdVk5RrcLPfQ)_