### PR TITLE
Draft Course 2 preview chapters + presentation versions

### DIFF
--- a/docs/plans/course-2/design_engineer_0.md
+++ b/docs/plans/course-2/design_engineer_0.md
@@ -1,0 +1,40 @@
+# Before you start
+
+_A few minutes before the first lesson. Read this once, set up your tools, and pick the thing you'll build. After that, it's hands on a keyboard._
+
+This is a course about becoming a design engineer: staying the one who directs the work when the machine can do the making. It is not a course about using AI to design faster, and it will not turn you into a software engineer. Both of those are being sold everywhere right now. Neither is this.
+
+Here is the honest version of what you leave with. You'll open real code and steer it instead of fearing it. You'll own a design-token system that keeps design and code in sync. You'll direct AI agents with guardrails instead of fighting their output. And you'll be able to say why a decision is right, which is the part of the job that isn't going anywhere. At the end you'll have shipped a small, real thing you can show.
+
+## Is this you
+
+Be honest, because the wrong fit wastes your money and my time.
+
+This is for you if you already think in systems, you've touched code or genuinely want to, and you're ready to work in it rather than talk about it. Mid or senior is the right altitude; the exercises assume you can hold a design decision on your own.
+
+This is not for you if you've never opened a code editor and don't intend to start, or if what you actually want is faster mockups. There's no shame in either. It just isn't what this is.
+
+## The one rule
+
+You build, you don't just watch. Every lesson ends with something you make, not something you understand. Watching me do it will feel like progress and leave you with nothing. The people who get value here are the ones who stop the video and go do the thing.
+
+## Set up before lesson one
+
+- A code editor. VS Code is fine.
+- An AI coding tool that runs in it (Cursor, or Claude in the editor — whatever you have access to).
+- A GitHub account, so your work has a home and a history.
+- The starter repo, cloned and running.
+
+Don't move on until `hello world` renders. If the tooling isn't proven now, every later lesson stalls on setup instead of learning.
+
+## Pick your thing
+
+Through the course you build toward one small project of your own: a component set, a themeable card, a tiny design system for a side project or a made-up brand. Pick it now. Keep it small, and keep it real enough that you'd be a little proud to show it. The capstone is that thing, finished.
+
+## One note
+
+This reflects how I actually work, not a certification. The tools will have changed by the time you watch this; the moves under them won't. When a specific tool here is dated, translate the move, not the button.
+
+Before lesson one, write down, somewhere you'll find it again, the one thing you want to be able to do at the end that you can't do today. One line. We'll come back to it.
+
+<!-- line: the one thing I want to be able to do that I can't today -->

--- a/docs/plans/course-2/design_engineer_1.md
+++ b/docs/plans/course-2/design_engineer_1.md
@@ -1,0 +1,37 @@
+# The new shape of the job
+
+_About ten minutes. One idea, one honest look at your own week, one line._
+
+Start with the thing nobody says plainly in a design all-hands. The execution layer of design, the making, is being automated, fast. A layout, a component library, a full page, generated in minutes. That isn't a threat to design. It's a threat to a specific kind of designer: the one whose whole value was the making.
+
+When making gets cheap, value moves to judgment. Deciding what's worth building. Knowing which of the twenty generated options is right, and being able to say why. I've written this as *taste is triage*: taste isn't decoration, it's the discipline of deciding where to spend attention you can no longer spend everywhere. That sentence is the whole course. Everything else is how to be that person in practice.
+
+## The split
+
+The field is pulling into two tiers.
+
+One is commodity execution: producing screens to spec, fast. That work is being automated, offshored, and compressed, and the people doing only that are now competing with a machine that doesn't sleep.
+
+The other is judgment: setting the standard, owning the system, directing the tools, and being the human who decides what ships. That tier is getting more valuable, because when anyone can generate, the scarce thing is knowing what's good and being accountable for it.
+
+A design engineer lives in the second tier. Not because they code like a senior engineer, most don't and don't need to, but because they work close enough to the material to steer it, own the system that keeps it coherent, and carry the judgment the machine has no way to hold.
+
+## The honest look
+
+This part only works if you're honest, so do it alone.
+
+Take your last two weeks of real work. Not your job description, what you actually did, hour by hour, as best you remember.
+
+Mark each piece: could a good AI tool, directed by someone competent, do most of this today? Not perfectly. Most of it.
+
+Add up the yeses. That percentage is your exposure. It isn't a verdict on you; plenty of excellent designers score high, because the industry paid them for exactly the work that's now cheap. It's a map of how much of your current value is moving under you, and how much sits in the judgment the machine can't reach.
+
+## Where this goes
+
+The rest of the course closes that gap on purpose. Working in code enough to steer it. Owning tokens so the system stays yours. Directing agents instead of being replaced by them. Sharpening the judgment part until it's the thing you're known for.
+
+Before the next lesson, write one line: the percentage you just found, and the one piece of your work you'd most want to move from the automatable column into the judgment column.
+
+<!-- line: my exposure, and the one thing I want to move -->
+
+That line is your reason for being here. Keep it.

--- a/docs/plans/course-2/presentation-and-remaining.md
+++ b/docs/plans/course-2/presentation-and-remaining.md
@@ -1,0 +1,59 @@
+# Presentation versions + remaining chapters (draft)
+
+The course chapters are written to double as talks and workshop segments — you present well and people already respond to that format. Chapter 01 is the standout: it's a keynote in its own right, and the same talk you can give at MACH and other conferences, which is also the top of the funnel for the course itself. One asset, three jobs (chapter, talk, funnel).
+
+---
+
+## Chapter 01 as a keynote — "The New Shape of the Job"
+
+*~15–20 min. Slide-by-slide script. This is the conference/MACH version.*
+
+**Slide 1 — Title.** *The New Shape of the Job.* Subtitle: "What happens to designers when making gets cheap." Say your one line: "I want to make an argument I've spent fifteen years earning."
+
+**Slide 2 — The unsaid thing.** "Here's what nobody says plainly in a design all-hands." Beat. "The making is being automated. Fast." Show a generated layout appearing in seconds.
+
+**Slide 3 — The reframe.** "That's not a threat to design. It's a threat to a specific designer: the one whose whole value was the making." Let it land.
+
+**Slide 4 — The thesis.** Big text: **Taste is triage.** "When making is cheap, value moves to judgment — deciding what's worth building, and being able to say why." This is the sentence they'll quote back to you.
+
+**Slide 5 — The split (the diagram).** Two tiers. Top: judgment — set the standard, own the system, direct the tools, decide what ships. Bottom: commodity execution — screens to spec, fast. Arrow: value flowing up. "The middle is hollowing out."
+
+**Slide 6 — Who lives on top.** "A design engineer. Not someone who codes like a senior engineer — most don't. Someone who works close enough to steer, owns the system, and carries the judgment the machine can't hold."
+
+**Slide 7 — The uncomfortable exercise (live).** Ask the room to do the two-week audit in their heads: what % could a competent person with AI do today? "Don't say it out loud. Just feel the number." This is the moment the talk becomes personal.
+
+**Slide 8 — Not a verdict, a map.** "A high number isn't a judgment on you. The industry paid you for exactly the work that's now cheap. It's a map of what's moving and what isn't."
+
+**Slide 9 — The move.** "The good news: the judgment tier is learnable, and the tools that threaten you are the same ones that get you there — if you direct them instead of racing them." One-line CTA (for the talk: your site / the course waitlist; for MACH: how this plays out in composable commerce).
+
+**Slide 10 — Close.** Back to *taste is triage.* "A cow can like something. You're not a cow. That's the job now." (Your line from the essay — it lands live.)
+
+---
+
+## Chapter 00 as a workshop kickoff
+
+Not a talk on its own; it's the room-setting for a workshop. Cover in ~5 minutes: what this is and isn't, the one rule (*you build, you don't just watch*), confirm everyone's tools run, and have each person write their one line. Then straight into the Chapter 01 audit as the first live beat.
+
+---
+
+## Remaining chapters — presentation-ready briefs (draft to full-content after validation)
+
+Each is written to work as a self-led lesson *and* a workshop segment: a point, a live demo, an exercise, a takeaway line.
+
+**02 · Work in code without becoming an engineer.** Point: you don't write it all, you steer it. Demo: take an agent's component, read it aloud, correct three things with intent. Exercise: ship one real component, fix three, say why each was wrong. Line: *the friction is the discipline, not the obstacle.*
+
+**03 · Tokens as the contract.** Point: tokens are the enforceable source of truth that keeps design and code one system. Demo: change a value, watch light/dark switch with no component edits. Exercise: build a small token system from the starter; theme it by values. Line: *if it only lives in the design file, you don't have a system, you have a file.*
+
+**04 · Direct the agents.** Point: agents are fast and sloppy by default; guardrails make their output trustworthy. Demo: a rules file catching a hardcoded value live. Exercise: write stop-conditions; prove they fire; hand off a diff, not a spec. Line: *you need the guardrails more than the AI does.*
+
+**05 · Taste as the deliverable.** Point: judgment is the paid work; here's how to run it. Demo: a drift audit on a pile of generated UI — the off-grid frame, the third gray, the one thing too many. Exercise: cut what doesn't belong, write the *because* for each cut. Line: *before you leave the house, take one thing off.*
+
+**06 · Reposition yourself.** Point: present as the resilient tier, not the fearful designer. Demo: rewrite a weak headline + a deliverable-list case study into evidence of judgment. Exercise: do it to your own. Line: *a designer who writes production code is easy to claim; make the page the proof.*
+
+**07 · Capstone — ship a design system with agents.** Point: put it together into a shown thing. Demo: walk your own capstone. Exercise: ship it; write the one-paragraph "why the decisions mattered"; optional paid feedback review. Line: *the finished, shown thing is the whole argument.*
+
+---
+
+*Build order reminder (from course-plan.md): validate with a warm pilot before writing full prose for 02–07 and recording videos. These briefs are enough to run a pilot workshop from.*
+
+*(End — draft, WIP.)*


### PR DESCRIPTION
## Summary

Draft content for the second self-led course, "Direct the Machine: The Design Engineer Path" (outline lives in `docs/plans/course-2-design-engineer-path.md`, in PR #238). All drafts — not wired into the live course system yet.

New files under `docs/plans/course-2/`:
- **`design_engineer_0.md`** — Chapter 00 "Before you start" (full draft), in the site's chapter voice/format (mirrors "Still Yourself"), ending with the write-a-line mechanic.
- **`design_engineer_1.md`** — Chapter 01 "The new shape of the job" (full draft) — the free preview that sells the rest, built on the *taste is triage* thesis.
- **`presentation-and-remaining.md`** — presentation versions, since the material is meant to double as talks/workshops:
  - Chapter 01 as a slide-by-slide conference/MACH **keynote script** (also the course's top-of-funnel).
  - Chapter 00 as a workshop kickoff.
  - Presentation-ready briefs for chapters 02–07 (point / demo / exercise / takeaway line each).

## Notes
- These are drafts in `docs/plans/` — not published, not in the course registry. Wiring them into `/secured/` routes + the manifest + video comes **after** a warm pilot validates demand (per `course-plan.md`).
- Separate concern from the confidentiality fix in #238; no file overlap.

---
_Generated by [Claude Code](https://claude.ai/code/session_017TTWdYXq2dmdVk5RrcLPfQ)_