### PR TITLE
Add mindfulness/wellbeing track planning doc (A Mindful Society 2019 + Mindful Meetings)

### DIFF
--- a/docs/plans/mindful-meetings-case-study.md
+++ b/docs/plans/mindful-meetings-case-study.md
@@ -1,0 +1,48 @@
+# Mindful Meetings — case study (draft)
+
+> **Status: WORK IN PROGRESS — draft.** The "showable" product leg of the mindfulness track. Grounded in the rebuilt repo (`github.com/jacquesramphal/mindful-meetings`, app name "MindSet"). Employer-agnostic. Follows the site case-study structure.
+
+| | |
+|---|---|
+| **Role** | Designer & Developer |
+| **Type** | Personal product · prototype |
+| **Stack** | React, TypeScript, Vite, Chakra UI, Framer Motion |
+| **Status** | Rebuilt · functional prototype |
+| **Repo** | github.com/jacquesramphal/mindful-meetings |
+
+## Key Learning
+
+The smallest thing that changes a meeting isn't a tool people have to adopt. It's a few seconds of structure at the start and the end. The design problem was subtraction: how little you can do and still change how a meeting feels.
+
+## Overview
+
+Meetings start cold and end abruptly. People arrive carrying the last thing, half-present, and leave without closing anything. Mindful Meetings gives a meeting a beginning and an end — a short opening pause to actually arrive, and a brief reflective close — without asking anyone to install a meditation habit.
+
+I first designed it in 2019 to accompany a workshop on mindfulness in the workplace. I rebuilt it recently, from scratch, in a modern front-end stack.
+
+## The Constraint
+
+The intervention has to be nearly invisible. Anything that announces "now we're doing mindfulness" gets quiet resistance in a work meeting. So it had to read as part of the meeting's structure, not a wellness add-on: configurable, skippable, and short by default.
+
+## Approach
+
+### One screen to set the shape of the meeting
+Setup is a single screen: name the meeting, set its length, set the opening pause (five minutes by default), and toggle audio guidance and a wrap-up reminder. The defaults are sensible enough that it runs with almost no decisions.
+
+### Bookend the time, don't fill it
+The flow is three deliberate beats: an opening pause to arrive, the meeting running quietly with an optional wrap-up nudge, and a short survey to close. The app does less on purpose. It holds the structure so the people in the room don't have to.
+
+### Calm by construction
+The interface is quiet by design — restrained color, soft motion, nothing competing for attention during a pause. For a product about creating space, the medium had to match the message, so the build leans on a controlled theme and gentle transitions rather than anything that pulls focus.
+
+## Outcome
+
+A functional prototype: a configurable meeting, an opening pause, a timed session with guidance and a wrap-up reminder, and a closing check-in. It never shipped as a product, and for a portfolio piece that's fine — it's a specific idea executed cleanly, and the rebuild shows current front-end craft.
+
+## What I Learned
+
+The hard part of "mindfulness at work" was never the technology. It was making the intervention small enough that people would let it happen at all. The interesting design work was in what I left out.
+
+---
+
+*Draft notes: employer-agnostic on purpose (personal rebuild) — mention the 2019 talk origin in passing, don't lead with the employer. Add 2–3 screenshots for the site version. Polish to "showable," not "shippable" (see course/mindfulness plans).*

--- a/docs/plans/mindfulness-outreach.md
+++ b/docs/plans/mindfulness-outreach.md
@@ -26,7 +26,7 @@ Principle: reconnect because you'd genuinely like to be back in touch, not becau
 
 ## 2 — Jay Vidyarthi (Still Ape / ex-Myplanet)
 
-*Strongest fit of anyone here: Still Ape is a fractional product team for wellbeing tech — the exact intersection of your skills and this track, run by a former colleague. Still lead relationship-first; the soft offer is appropriate because Still Ape literally brings in extra hands.*
+*Strongest fit of anyone here: Still Ape is a fractional product team for wellbeing tech — the exact intersection of your skills and this track, run by someone you have real shared history with (he came in to co-facilitate a Myplanet Mind in-house workshop you were co-leading). Lead relationship-first; the soft offer is appropriate because Still Ape literally brings in extra hands.*
 
 **Subject:** Ex-Myplanet, still circling the wellbeing-tech world
 
@@ -34,7 +34,7 @@ Principle: reconnect because you'd genuinely like to be back in touch, not becau
 >
 > I came across Still Ape and had a big "of course" moment — a fractional product team for wellbeing tech is exactly the intersection I keep coming back to. Congratulations on building it; the "tech for wellbeing" framing is the thing I care most about.
 >
-> We overlapped at Myplanet, and I've stayed close to this space: design systems and production front-end as the day job, and on the side a mindful-meetings app I rebuilt, a short reflective course, and the A Mindful Society talk I gave in 2019.
+> We go back a bit — you came in to co-facilitate one of the Myplanet Mind in-house workshops I was co-leading, and that stuck with me. I've stayed close to this space since: design systems and production front-end as the day job, and on the side a mindful-meetings app I rebuilt, a short reflective course, and the A Mindful Society talk I gave in 2019.
 >
 > I'd love to reconnect and hear how you're working now. And if you ever bring in extra hands on the design or build side, I'd be genuinely interested — but mostly I just wanted to say what you're doing looks great.
 >

--- a/docs/plans/mindfulness-outreach.md
+++ b/docs/plans/mindfulness-outreach.md
@@ -1,0 +1,50 @@
+# Mindfulness network — outreach drafts
+
+> **Status: WORK IN PROGRESS — drafts.** Warm reconnects, relationship-first. Not to be sent as-is without a personal pass. See the "warm connections" section in `mindfulness-track.md` for the strategy.
+
+Principle: reconnect because you'd genuinely like to be back in touch, not because they're leads. Lead with the relationship, mention your work as shared-interest signals (not a pitch), and only get specific if there's a fit. The 2019 talk documentation is your true, natural reason to reach out right now.
+
+---
+
+## 1 — Michael Apollo (The Mindful Institute / ex-Myplanet)
+
+*Deepest history; he organized the 2019 talk. Start here.*
+
+**Subject:** A blast from the A Mindful Society past
+
+> Hi Michael,
+>
+> I've been pulling together an archive of my work and landed back on our A Mindful Society 2019 session — "Creating Space." It reminded me how much I valued working with you in the Myplanet days, and I've been meaning to reconnect for a while.
+>
+> What are you focused on now with the Mindful Institute? I've kept a foot in this world — I built a small "mindful meetings" tool, I still write, and I run a short reflective course — so I'd genuinely love to hear what you're building these days.
+>
+> No agenda beyond catching up properly. Would be good to talk.
+>
+> Jacques
+
+---
+
+## 2 — Jay Vidyarthi (Still Ape / ex-Myplanet)
+
+*Strongest fit of anyone here: Still Ape is a fractional product team for wellbeing tech — the exact intersection of your skills and this track, run by a former colleague. Still lead relationship-first; the soft offer is appropriate because Still Ape literally brings in extra hands.*
+
+**Subject:** Ex-Myplanet, still circling the wellbeing-tech world
+
+> Hi Jay,
+>
+> I came across Still Ape and had a big "of course" moment — a fractional product team for wellbeing tech is exactly the intersection I keep coming back to. Congratulations on building it; the "tech for wellbeing" framing is the thing I care most about.
+>
+> We overlapped at Myplanet, and I've stayed close to this space: design systems and production front-end as the day job, and on the side a mindful-meetings app I rebuilt, a short reflective course, and the A Mindful Society talk I gave in 2019.
+>
+> I'd love to reconnect and hear how you're working now. And if you ever bring in extra hands on the design or build side, I'd be genuinely interested — but mostly I just wanted to say what you're doing looks great.
+>
+> Jacques
+
+---
+
+## Notes before sending
+- **Personalize each** — one specific, true detail per message (a shared project, a moment from Myplanet). Generic warmth reads as a template.
+- **Conflict/moonlighting:** if the Jay V thread turns into paid/fractional work while you're at Orium, that's a moonlighting question — clear it against your employment terms first. Reconnecting and talking is fine; taking paid work is the line to check.
+- **Don't reference the LinkedIn "opening"** you noticed on Michael's team. It's a reason to talk, not something to raise — mentioning it reads as presumptuous.
+- **Sequence:** Michael first (documentation gives you a true reason today), Jay V second. Space them; don't blast both the same hour.
+- **Attach nothing / link lightly.** If they ask, the mindful-meetings repo, Still Yourself, and the talk are ready to share.

--- a/docs/plans/mindfulness-track.md
+++ b/docs/plans/mindfulness-track.md
@@ -22,8 +22,15 @@ Framing note: this track has a smaller ceiling and is off the primary (design-en
 > **When/where:** Saturday, May 25, 2019, 4:00–5:00 PM · Chestnut Conference Centre, Lombard room (capacity 65) · conference ran May 24–27
 > **Content:** a workshop on creating space for mindfulness in the workplace, built around a workplace-mindfulness product concept.
 
+**Learning objectives (as presented):**
+1. Explore how mindfulness shapes culture and retention in an agile workplace.
+2. Understand how Myplanet brings mindfulness into the workplace.
+3. See how we empower individuals to practice mindfulness at work through professional development.
+
+*Employer-agnostic version for the public record: swap #2 to "how a product team brings mindfulness into the workplace."*
+
 **Context that makes it credible (for a bio/blurb):**
-- A Mindful Society is a leading Canadian mindfulness conference; 2019 was its 5th year, theme "Be. Act. Belong."
+- A Mindful Society is a leading Canadian mindfulness conference; 2019 was its 5th year, theme "Be. Act. Belong." It now operates as **The Mindful Institute** (mindfulinstitute.org).
 - The audience was explicitly **not beginners** — professionals and practitioners (26% with deep/intensive practice; 23% facilitate guided sessions themselves). Presenting to that room is a real credential.
 - The guidelines asked presenters to **focus on content, not sell products** — so the workshop stood on substance, not a pitch.
 
@@ -32,6 +39,7 @@ Framing note: this track has a smaller ceiling and is off the primary (design-en
 **To make it verifiable/linkable (worth chasing):**
 - Workshops were **audio-recorded for the A Mindful Society podcast / social** — track down whether a recording of this session exists. A recording or a public program listing is the strongest proof.
 - The deck (*MP Mind Master JR*, Nov 2019), the primer PDF, and the 2019 mindfulness report are supporting artifacts.
+- External coverage/reference: `wkup.org/mindful-society-conference-in-canada` (a write-up of the conference).
 
 ---
 
@@ -46,6 +54,20 @@ Framing note: this track has a smaller ceiling and is off the primary (design-en
 - *Shippable* (don't): a launched, supported wellness app. That category is crowded and near-unmonetizable, it's off your primary thesis, and it competes with higher-EV work.
 
 ---
+
+## Warm connections & opportunity
+
+Real, warm relationships in this space — the distribution advantage that matters more than a bigger cold market, and exactly the lane that fits someone who won't cold-sell.
+
+- **Michael Apollo** — Mindful Gateway / now The Mindful Institute (A Mindful Society). Ex-Myplanet (Orium); long shared history and close prior working relationship. He organized the 2019 talk.
+- **Jay V** — ex-Myplanet, now runs **Still Ape** (stillape.com). Same network, intersecting with wellbeing/product. *(Site was bot-blocked when checked — confirm what Still Ape actually does before any pitch.)*
+
+**How to approach it (honest):**
+- **Reconnect warm first, no ask.** With people you have history with, a genuine "what are you building now?" opens more doors than a pitch. Lead with the relationship.
+- **Then make it specific, if there's a fit.** "I could help with [design/product X]" beats "let me know if you ever need support" — vague offers get vague replies. Name the thing once you know what they need.
+- **Don't over-read the LinkedIn signal.** Michael's designers not listing a Mindful Society role might be an opening, or might mean nothing. Treat it as a reason to talk, not proof of a vacancy — and don't walk in implying you spotted a gap in their team; that reads as presumptuous.
+- **This is the one place the two tracks combine well:** a design engineer who genuinely gets mindfulness/wellbeing and has shipped in it. Differentiated for exactly these orgs.
+- **Set expectations:** small orgs may not have a hire's budget — this could be fractional, project, or advisory, or simply optionality and a warm door. If it turns into paid work, mind the Orium moonlighting terms.
 
 ## Placement & next steps
 - **Where it lives:** the mindfulness/wellbeing track — NOT the design-engineering résumé or hire page. If added to the site record, keep it employer-agnostic and strip third-party contacts.

--- a/docs/plans/mindfulness-track.md
+++ b/docs/plans/mindfulness-track.md
@@ -1,0 +1,57 @@
+# Mindfulness / Wellbeing Track
+
+> **Status: WORK IN PROGRESS.** Planning doc — not site content, not rendered. Lives in the repo; if public, this file is visible. Contacts of third parties intentionally omitted.
+
+A **secondary** track, kept deliberately separate from the design-engineering résumé and hire page. Its value is authenticity and coherence: you have three real artifacts here going back to 2019, which most people can't assemble.
+
+**The three legs:**
+- **Talk** — A Mindful Society 2019 (below).
+- **Course** — *Still Yourself* (live on the site).
+- **Product** — *Mindful Meetings* (designed 2019, rebuilt; the "showable" plan below).
+
+Framing note: this track has a smaller ceiling and is off the primary (design-engineering, resilient-tier) thesis. Build it because it's genuine and differentiated, not because it's where the money is. Keep the wall up between the two tracks.
+
+---
+
+## Speaking entry — A Mindful Society 2019
+
+**Verified from the presenter guidelines + organizer confirmation.**
+
+> **A Mindful Society 2019** — Toronto
+> **Session:** *Creating Space: Empowering the Workplace with Myplanet Mind* — workshop, solo (no co-facilitators)
+> **When/where:** Saturday, May 25, 2019, 4:00–5:00 PM · Chestnut Conference Centre, Lombard room (capacity 65) · conference ran May 24–27
+> **Content:** a workshop on creating space for mindfulness in the workplace, built around a workplace-mindfulness product concept.
+
+**Context that makes it credible (for a bio/blurb):**
+- A Mindful Society is a leading Canadian mindfulness conference; 2019 was its 5th year, theme "Be. Act. Belong."
+- The audience was explicitly **not beginners** — professionals and practitioners (26% with deep/intensive practice; 23% facilitate guided sessions themselves). Presenting to that room is a real credential.
+- The guidelines asked presenters to **focus on content, not sell products** — so the workshop stood on substance, not a pitch.
+
+**Record/site version (employer-agnostic):** keep the historical session title verbatim (it's the real title), but in any new bio prose describe it as *"a workplace-mindfulness product I designed"* rather than leading with the employer brand.
+
+**To make it verifiable/linkable (worth chasing):**
+- Workshops were **audio-recorded for the A Mindful Society podcast / social** — track down whether a recording of this session exists. A recording or a public program listing is the strongest proof.
+- The deck (*MP Mind Master JR*, Nov 2019), the primer PDF, and the 2019 mindfulness report are supporting artifacts.
+
+---
+
+## Product — Mindful Meetings
+
+- **What:** a workplace-mindfulness product (the "Myplanet Mind" / Mindful Meetings concept behind the 2019 talk) — bringing mindful practice into everyday work.
+- **Status:** designed in 2019, **did not ship**. You have since **rebuilt it** and hold the repo. The rebuilt version is personal/employer-agnostic.
+- **Repo:** local only (`~/Documents/src/trusted/_personal/mindful-meetings`) — not reachable from here. **Push it to GitHub** (private is fine) and I can pull it in to draft the case study.
+
+**The call: polish it to *showable*, not *shippable*.**
+- *Showable* (do): a clean repo, a short case study, a working demo — the product leg of this track. A weekend, high return as a portfolio/record artifact.
+- *Shippable* (don't): a launched, supported wellness app. That category is crowded and near-unmonetizable, it's off your primary thesis, and it competes with higher-EV work.
+
+---
+
+## Placement & next steps
+- **Where it lives:** the mindfulness/wellbeing track — NOT the design-engineering résumé or hire page. If added to the site record, keep it employer-agnostic and strip third-party contacts.
+- [ ] Confirm the talk title as it appeared on the public program (it may differ slightly from the internal deck name).
+- [ ] Hunt for the A Mindful Society podcast/audio recording of the session → link it.
+- [ ] Push the `mindful-meetings` repo to GitHub → then draft the "showable" case study.
+- [ ] Decide the site home for this track (a small Speaking/Wellbeing section, or fold into the record) before publishing anything live.
+
+*(End — WIP.)*

--- a/docs/plans/mindfulness-track.md
+++ b/docs/plans/mindfulness-track.md
@@ -60,7 +60,7 @@ Framing note: this track has a smaller ceiling and is off the primary (design-en
 Real, warm relationships in this space — the distribution advantage that matters more than a bigger cold market, and exactly the lane that fits someone who won't cold-sell.
 
 - **Michael Apollo** — Mindful Gateway / now The Mindful Institute (A Mindful Society). Ex-Myplanet (Orium); long shared history and close prior working relationship. He organized the 2019 talk.
-- **Jay V** — ex-Myplanet, now runs **Still Ape** (stillape.com). Same network, intersecting with wellbeing/product. *(Site was bot-blocked when checked — confirm what Still Ape actually does before any pitch.)*
+- **Jay Vidyarthi** — ex-Myplanet, now founder of **Still Ape** (stillape.com), a fractional product team for wellbeing tech ("tech for wellbeing" — mindfulness/meditation, healing, social, education/youth). Real shared history: he co-facilitated a Myplanet Mind in-house workshop you were co-leading. This is the strongest-fit lead in the whole track — the exact intersection of your skills and this thread, a fractional model that brings in extra hands, run by someone who already knows your work.
 
 **How to approach it (honest):**
 - **Reconnect warm first, no ask.** With people you have history with, a genuine "what are you building now?" opens more doors than a pitch. Lead with the relationship.


### PR DESCRIPTION
## Summary

Adds `docs/plans/mindfulness-track.md` — documents the secondary mindfulness/wellbeing track, kept deliberately separate from the design-engineering résumé/hire page.

Contents:
- **Verified speaking entry** — A Mindful Society 2019, Toronto: *"Creating Space: Empowering the Workplace with Myplanet Mind,"* solo workshop, Sat May 25 2019, 4–5 PM, Chestnut Conference Centre (Lombard, cap. 65). Includes credibility context (professional/practitioner audience, not beginners) and an employer-agnostic framing note for any site version.
- **Mindful Meetings product** — designed 2019, didn't ship, since rebuilt; the "polish to showable, not shippable" plan. Repo is local-only and needs pushing to GitHub before a case study can be drafted.
- **The three legs** (talk + Still Yourself course + Mindful Meetings product) and next steps.

## Notes
- Planning doc only — not site content, not rendered.
- Third-party contact details intentionally omitted.
- Open follow-ups noted in the doc: confirm the public program title, find the conference audio recording, push the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_017TTWdYXq2dmdVk5RrcLPfQ)_