### PR TITLE
Add an RSS link to the footer

### DIFF
--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -62,7 +62,11 @@
                 <p class="subtle">Site</p>
                 <ul>
                   <li v-for="(item, index) in menuItems3" :key="index">
-                    <TextLink :label="item.text" :route="item.route" />
+                    <TextLink
+                      :label="item.text"
+                      :route="!item.external ? item.route : undefined"
+                      :link="item.external ? item.route : undefined"
+                    />
                   </li>
                 </ul>
               </div>
@@ -198,6 +202,7 @@ export default {
       menuItems3: [
         { text: 'Journal', route: '/doc/design-learnings' },
         { text: 'About', route: '/about' },
+        { text: 'RSS', route: '/rss.xml', external: true },
         { text: 'AI Ethics', route: '/doc/ai-ethics' },
         { text: 'Privacy', route: '/doc/privacy' },
         { text: 'Accessibility', route: '/doc/accessibility' },


### PR DESCRIPTION
Surfaces the existing `/rss.xml` feed as a visible link in the footer.

## Changes

- Added an **RSS** item to the footer's "Site" column, linking to `/rss.xml`.
- It's rendered as an external link (`link`, not `route`), since `rss.xml` is a static file served directly, not a Vue route.

The feed itself already existed (built by `scripts/generate-rss.js`, discoverable via `<link rel="alternate">` in the head) — this just makes it visible to people, not only feed readers.

## Verification

- `vue-cli-service lint` — clean
- `vue-cli-service build` — succeeds
- Rendered check: footer "Site" column shows one RSS link with `href="/rss.xml"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZLuuBrZkHdmM6NAFpwFbJ)_