### PR TITLE
Add subtle film grain to the mesh gradient

### DIFF
--- a/public/lab/gradient-placeholders/generator.js
+++ b/public/lab/gradient-placeholders/generator.js
@@ -273,7 +273,10 @@ function drawMesh(rng, w, h, id, colors, pattern) {
     ).toFixed(1)}" r="${wr.toFixed(1)}" fill="url(#${gid})"/>`;
   }
 
-  return `<defs>${defs}</defs><g filter="url(#${id}-warp)"><rect x="-12%" y="-12%" width="124%" height="124%" fill="url(#${id}-base)"/>${blobs}${whites}</g>`;
+  // A small amount of film grain over everything for texture.
+  const noise = `<filter id="${id}-noise" x="0" y="0" width="100%" height="100%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"/><feColorMatrix in="n" type="saturate" values="0"/></filter>`;
+
+  return `<defs>${defs}${noise}</defs><g filter="url(#${id}-warp)"><rect x="-12%" y="-12%" width="124%" height="124%" fill="url(#${id}-base)"/>${blobs}${whites}</g><rect width="${w}" height="${h}" filter="url(#${id}-noise)" opacity="0.14" style="mix-blend-mode:overlay"/>`;
 }
 
 function drawBloom(rng, w, h, ramp) {

--- a/src/utils/gradientPlaceholder.ts
+++ b/src/utils/gradientPlaceholder.ts
@@ -392,9 +392,14 @@ function drawMesh(
     ).toFixed(1)}" r="${wr.toFixed(1)}" fill="url(#${gid})"/>`;
   }
 
+  // A small amount of film grain over everything for texture. Monochrome
+  // turbulence, overlaid faintly so it reads as grain, not static.
+  const noise = `<filter id="${id}-noise" x="0" y="0" width="100%" height="100%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"/><feColorMatrix in="n" type="saturate" values="0"/></filter>`;
+
   // The base is oversized and inside the warp group so displacement never
-  // reveals a transparent edge. White spots warp with everything else.
-  return `<defs>${defs}</defs><g filter="url(#${id}-warp)"><rect x="-12%" y="-12%" width="124%" height="124%" fill="url(#${id}-base)"/>${blobs}${whites}</g>`;
+  // reveals a transparent edge. White spots warp with everything else; the grain
+  // sits flat on top.
+  return `<defs>${defs}${noise}</defs><g filter="url(#${id}-warp)"><rect x="-12%" y="-12%" width="124%" height="124%" fill="url(#${id}-base)"/>${blobs}${whites}</g><rect width="${w}" height="${h}" filter="url(#${id}-noise)" opacity="0.14" style="mix-blend-mode:overlay"/>`;
 }
 
 function drawBloom(rng: Rng, w: number, h: number, ramp: string[]): string {


### PR DESCRIPTION
## What this changes

Adds a small amount of film grain to the mesh placeholder for a bit of texture and visual interest, on the otherwise-smooth gradient.

- Monochrome fractal noise (`feTurbulence` + `feColorMatrix saturate="0"`), overlaid at low opacity (0.14) with `mix-blend-mode: overlay` — subtle, reads as grain rather than static.
- **No text layer.** I tried layering the title words back on with a matching gradient fill, but per your call we're keeping the placeholder purely the gradient. Reverted.

## Scope

Just the two generator files (`src/utils/gradientPlaceholder.ts` and the lab mirror). Everything else — the mesh, definition, and randomized whitespace — already landed via #246 and #247, both now merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wq3WN9D2LctukmcB3JAVVx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wq3WN9D2LctukmcB3JAVVx)_