### PR TITLE
Revert #249 mobile type changes; reorder homepage to Work → About → Writing

### DIFF
--- a/src/assets/styles/scss/typography.scss
+++ b/src/assets/styles/scss/typography.scss
@@ -426,25 +426,20 @@ figcaption {
    RESPONSIVE BREAKPOINTS
    ========================================================================= */
 
-/* Mobile (XS) - Reduced heading scale for tighter hierarchy on phones.
-   h1/.display are left on their default tokens (the 4.8rem/48px floor reads
-   fine at this root size). h2–h4 are pulled down a step so section titles and
-   in-article headings sit closer to the 20px body and stop dominating the
-   viewport. h5/h6 already sit near body size and are unchanged. */
+/* Mobile (XS) - Drop h3 and below for better hierarchy */
 @media only screen and (max-width: 767px) {
+
+  /* design-guard:ignore */
   h2 {
-    /* design-guard:ignore */
-    font-size: 3rem;
+    font-size: var(--size-9);
   }
 
   h3 {
-    /* design-guard:ignore */
-    font-size: 2.5rem;
+    font-size: var(--size-7);
   }
 
   h4 {
-    /* design-guard:ignore */
-    font-size: 2.1rem;
+    font-size: var(--size-6);
   }
 
   h5 {
@@ -462,6 +457,7 @@ h1 + p {
 
 /* Tablet (MD) */
 @media only screen and (min-width: 768px) {
+
   /* design-guard:ignore */
   h1 {
     padding-block-end: var(--spacing-xxxs);
@@ -480,6 +476,7 @@ h1 + p {
 
 /* Large Desktop (XL) */
 @media only screen and (min-width: 1441px) {
+
   /* design-guard:ignore */
   .display p {
     font-size: var(--font-600);

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -24,9 +24,6 @@
       :viewAllTo="{ name: 'Library' }"
     />
 
-    <!-- WRITING SECTION -->
-    <CardRow2 title="Writing" kind="writing" :viewAllTo="{ name: 'Library' }" />
-
     <!-- ABOUT SECTION -->
     <AnimatedComponent>
       <TextGrid3
@@ -39,6 +36,9 @@
         route="/about"
       />
     </AnimatedComponent>
+
+    <!-- WRITING SECTION -->
+    <CardRow2 title="Writing" kind="writing" :viewAllTo="{ name: 'Library' }" />
 
     <div class="vertical-wordmark" aria-hidden="true">Jacques Ramphal</div>
   </PageWrapper>


### PR DESCRIPTION
## Summary

Follow-up to the already-merged #249. Two changes:

1. **Revert the mobile type reductions** that #249 introduced — `typography.scss` is restored to its pre-#249 state (drops the mobile `h2`–`h4` heading-scale overrides). No type/scale change ships from this branch.
2. **Reorder the homepage** so About sits between the work and the writing:

   `Hero → Select Work → About → Writing`

   (#249 shipped `Hero → Select Work → Writing → About`.)

## Changes
- `src/assets/styles/scss/typography.scss` — reverted to `main`'s pre-#249 version
- `src/pages/HomePage.vue` — moved the About section above Writing

Net: +12 / −15 across 2 files.

## Notes
- Layout treatment (cards vs. list) remains out of scope — to be handled separately by adapting the existing list component as a mobile-only swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A15o9eE32j68yTFjW51Enw)_