### PR TITLE
Fluid body-scale type on mobile + fix presenter counter colour

### DIFF
--- a/src/assets/styles/scss/_config.scss
+++ b/src/assets/styles/scss/_config.scss
@@ -246,10 +246,10 @@
   --font-600: var(--size-7);
   /* Lead Paragraph (p under H1) */
   --font-p-lead: clamp(var(--size-5), 2.5vw, var(--size-7));
-  /* H5 + Paragraph */
-  --font-500: var(--size-5);
-  /* H6 + Paragraph Small*/
-  --font-400: var(--size-4);
+  /* H5 + Paragraph — fluid: unchanged 2rem (20px) on desktop, shrinks to 1.7rem (17px) on mobile */
+  --font-500: clamp(1.7rem, 1.41rem + 0.76vw, 2rem);
+  /* H6 + Paragraph Small — fluid: unchanged 1.6rem (16px) on desktop, shrinks to 1.4rem (14px) on mobile */
+  --font-400: clamp(1.4rem, 1.2rem + 0.5vw, 1.6rem);
 
   /*
   --font-300: clamp(0.7rem, 0.66rem + 0.2vw, 0.8rem);

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -349,14 +349,16 @@ export default {
   padding: var(--spacing-xxxs) var(--spacing-xxs);
 }
 .button--small {
-  font-size: var(--font-2xs);
+  /* Body-scale token (16px desktop) so button text shrinks on mobile like body copy */
+  font-size: var(--font-400);
   // padding: var(--spacing-xxs);
   padding: 0.95rem 1.25rem 1rem 1.25rem;
 
   /* border-radius: 100px; */
 }
 .button--large {
-  font-size: var(--font-xs);
+  /* Body-scale token (20px desktop) so button text shrinks on mobile like body copy */
+  font-size: var(--font-500);
   padding: 1.5rem 2rem 1.65rem 2rem;
   // padding: var(--spacing-xs);
 }

--- a/src/components/PresenterBar/PresenterBar.vue
+++ b/src/components/PresenterBar/PresenterBar.vue
@@ -58,6 +58,10 @@ export default {
   align-items: center;
   gap: var(--spacing-xxs);
   background: var(--background);
+  /* PresenterBar is teleported to <body>, outside #app where --foreground is
+     applied, so text here would otherwise inherit the browser default (black)
+     in both themes. Set the themed colour explicitly. */
+  color: var(--foreground);
   border: var(--border);
   border-radius: 999px;
   padding: var(--spacing-xxs) var(--spacing-xs);


### PR DESCRIPTION
Supersedes #252 (that PR only made the `p` rule fluid; this fixes it at the token level so all the body-scale text scales consistently). **Desktop type sizes are unchanged** — only small screens shrink.

## 1. Fluid body-scale tokens (`_config.scss`)

Both were fixed values that never shrank on mobile:

| Token | Before | After | Desktop | Mobile floor |
|---|---|---|---|---|
| `--font-500` | `var(--size-5)` (20px) | `clamp(1.7rem, 1.41rem + 0.76vw, 2rem)` | **20px (same)** | 17px |
| `--font-400` | `var(--size-4)` (16px) | `clamp(1.4rem, 1.2rem + 0.5vw, 1.6rem)` | **16px (same)** | 14px |

Because these are the shared body tokens, this fixes **at once**: paragraphs, `h5`, the chat message text and the "Let's Chat" header (both used `--font-500` and were pinned at 20px), footers, article cards, form inputs, and small labels/eyebrows.

## 2. Button text scales on mobile (`Button.vue`)

`.button--large` and `.button--small` used the fixed absolute tokens (`--font-xs`/`--font-2xs`). Remapped onto the body tokens (`--font-500`/`--font-400`) — **same desktop px**, now fluid on mobile. Left the other 40+ `--font-xs`/`2xs` usages untouched.

## 3. Presenter "1 / X" counter colour (`PresenterBar.vue`)

The counter rendered **black in both light and dark themes**. Root cause: `PresenterBar` is teleported to `<body>`, but the text colour `--foreground` is set on `#app` (`main.scss:26`), not `body` — so the uncoloured counter `<span>` fell back to the browser default black. The arrow/Exit buttons looked fine only because `.button--ghost` sets its own colour.

**Not a mobile-only issue** — it was wrong at every width in both themes. Fix: `color: var(--foreground)` on `.presenter-bar`.

## Note on the Share button

I couldn't reproduce a broken Share dropdown — in a real browser it opens correctly (X / LinkedIn / Facebook / Copy link). The component logic in `SelectorCta.vue` is sound. If it's failing on the live site, it's likely environmental (stale deploy or browser-specific); happy to dig in with a specific repro (which page + browser, and what happens on tap).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3ndquiTnbhNhT9BdXRLNk)_